### PR TITLE
fix: resolve 24 failing unit tests blocking CI/CD pipeline

### DIFF
--- a/packages/ghosthands/__tests__/unit/workers/costOnFailure.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/costOnFailure.test.ts
@@ -69,21 +69,21 @@ describe('CostTracker getSnapshot() failure edge cases', () => {
 
   test('BudgetExceededError includes cost snapshot at time of exceeded budget', () => {
     const tracker = new CostTracker({ jobId: 'budget-err-1', qualityPreset: 'speed' });
-    // speed preset has $0.02 budget
+    // speed preset has $0.05 budget
 
     try {
       tracker.recordTokenUsage({
         inputTokens: 50000,
         outputTokens: 20000,
-        inputCost: 0.015,
-        outputCost: 0.01,
+        inputCost: 0.035,
+        outputCost: 0.025,
       });
       // Should have thrown
       expect(true).toBe(false);
     } catch (err) {
       expect(err).toBeInstanceOf(BudgetExceededError);
       const budgetErr = err as BudgetExceededError;
-      expect(budgetErr.costSnapshot.totalCost).toBeCloseTo(0.025, 4);
+      expect(budgetErr.costSnapshot.totalCost).toBeCloseTo(0.06, 4);
       expect(budgetErr.costSnapshot.inputTokens).toBe(50000);
       expect(budgetErr.costSnapshot.outputTokens).toBe(20000);
       expect(budgetErr.jobId).toBe('budget-err-1');
@@ -116,17 +116,17 @@ describe('CostTracker getSnapshot() failure edge cases', () => {
     tracker.recordTokenUsage({
       inputTokens: 1000,
       outputTokens: 500,
-      inputCost: 0.005,
-      outputCost: 0.003,
+      inputCost: 0.020,
+      outputCost: 0.015,
     });
 
-    // This will exceed the $0.02 budget
+    // This will exceed the $0.05 budget
     try {
       tracker.recordTokenUsage({
         inputTokens: 10000,
         outputTokens: 5000,
-        inputCost: 0.010,
-        outputCost: 0.008,
+        inputCost: 0.015,
+        outputCost: 0.010,
       });
     } catch {
       // Expected
@@ -134,7 +134,7 @@ describe('CostTracker getSnapshot() failure edge cases', () => {
 
     // Snapshot should reflect the full accumulated cost (including the over-budget usage)
     const snap = tracker.getSnapshot();
-    expect(snap.totalCost).toBeCloseTo(0.026, 4);
+    expect(snap.totalCost).toBeCloseTo(0.06, 4);
     expect(snap.inputTokens).toBe(11000);
     expect(snap.outputTokens).toBe(5500);
   });
@@ -324,25 +324,25 @@ describe('Cost recording on all exit paths', () => {
 
   test('budget exceeded: includes the cost that triggered the limit', () => {
     const tracker = new CostTracker({ jobId: 'budget-exceed-1', qualityPreset: 'speed' });
-    // speed budget = $0.02
+    // speed budget = $0.05
 
     // First call within budget
     tracker.recordTokenUsage({
       inputTokens: 5000,
       outputTokens: 1000,
-      inputCost: 0.008,
-      outputCost: 0.004,
+      inputCost: 0.020,
+      outputCost: 0.010,
     });
     tracker.recordAction();
 
-    // Second call exceeds budget
+    // Second call exceeds budget ($0.030 + $0.025 = $0.055 > $0.05)
     let budgetSnapshot: any = null;
     try {
       tracker.recordTokenUsage({
         inputTokens: 8000,
         outputTokens: 3000,
-        inputCost: 0.010,
-        outputCost: 0.005,
+        inputCost: 0.015,
+        outputCost: 0.010,
       });
     } catch (err) {
       if (err instanceof BudgetExceededError) {
@@ -351,7 +351,7 @@ describe('Cost recording on all exit paths', () => {
     }
 
     expect(budgetSnapshot).not.toBeNull();
-    expect(budgetSnapshot.totalCost).toBeCloseTo(0.027, 4);
+    expect(budgetSnapshot.totalCost).toBeCloseTo(0.055, 4);
     expect(budgetSnapshot.inputTokens).toBe(13000);
     expect(budgetSnapshot.outputTokens).toBe(4000);
 

--- a/packages/ghosthands/__tests__/unit/workers/costTracking.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/costTracking.test.ts
@@ -144,14 +144,14 @@ describe('CostTracker cost calculation', () => {
   });
 
   test('throws BudgetExceededError when cost exceeds task budget', () => {
-    // 'quality' preset has $0.30 budget
+    // 'quality' preset has $0.50 budget
     // Simulate a large usage that exceeds it
     expect(() => {
       tracker.recordTokenUsage({
         inputTokens: 100_000,
         outputTokens: 50_000,
-        inputCost: 0.20,
-        outputCost: 0.15,
+        inputCost: 0.30,
+        outputCost: 0.25,
       });
     }).toThrow(BudgetExceededError);
   });

--- a/packages/ghosthands/src/config/env.ts
+++ b/packages/ghosthands/src/config/env.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const envSchema = z.object({
-  NODE_ENV: z.enum(['development', 'staging', 'production']).default('development'),
+  NODE_ENV: z.enum(['development', 'staging', 'production', 'test']).default('development'),
   DATABASE_URL: z.string().url().optional(),
   SUPABASE_URL: z.string().url().optional(),
   SUPABASE_SECRET_KEY: z.string().min(1).optional(),


### PR DESCRIPTION
## Summary
- Fix 24 unit test failures that block the entire GH CI/CD pipeline (Docker build → ECR push → deploy webhook → EC2 rolling deploy)
- 729 tests now pass, 0 failures

## Root Causes

**1. NODE_ENV Zod validation (19 tests fixed)**
- `env.ts` schema only allowed `development|staging|production` for `NODE_ENV`
- vitest/bun sets `NODE_ENV=test`, causing ZodError on any module that imports env config
- Fix: Added `'test'` to the enum

**2. CostTracker budget thresholds (3 tests fixed)**
- Tests assumed old budget values (`speed: $0.02`, `quality: $0.30`)
- Implementation uses `speed: $0.05`, `quality: $0.50`
- Fix: Updated test cost values to exceed actual thresholds

**3. ResumeDownloader bun compatibility (2 tests fixed)**
- `vi.stubGlobal()` doesn't exist in bun test runner
- `.resolves.not.toThrow()` incompatible with bun
- Fix: Direct `globalThis.fetch` assignment + simple await pattern

## Files Changed
- `packages/ghosthands/src/config/env.ts` — Add `'test'` to NODE_ENV enum
- `packages/ghosthands/__tests__/unit/workers/costTracking.test.ts` — Fix budget thresholds
- `packages/ghosthands/__tests__/unit/workers/costOnFailure.test.ts` — Fix budget thresholds
- `packages/ghosthands/__tests__/unit/workers/resumeDownloadIntegration.test.ts` — Fix bun compat

## Linear
Fixes [WEK-76](https://linear.app/wecrew-axon/issue/WEK-76/p0-fix-24-failing-unit-tests-blocking-gh-cicd-pipeline)

## Test Plan
- [x] `bun run test:unit` — 729 pass, 0 fail
- [ ] CI pipeline passes (typecheck + unit + integration + Docker build)
- [ ] Deploy webhook fires to VALET staging
- [ ] EC2 rolling deploy triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)