### PR TITLE
fix(docker): add scripts workspace to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY package.json bun.lock turbo.json ./
 
 # Copy package.json for workspace resolution
 COPY packages/ghosthands/package.json packages/ghosthands/
+COPY scripts/package.json scripts/
 
 # Install dependencies (magnitude-core and magnitude-extract come from npm)
 RUN bun install --frozen-lockfile
@@ -26,6 +27,7 @@ FROM deps AS build
 
 # Copy source
 COPY packages/ packages/
+COPY scripts/ scripts/
 COPY tsconfig.base.json ./
 
 # Build


### PR DESCRIPTION
## Summary
- WEK-78 added `"scripts"` as a Bun workspace but the Dockerfile only copied `packages/ghosthands/package.json`
- Docker build failed with `Workspace not found "scripts"` during `bun install --frozen-lockfile`
- Fix: Copy `scripts/package.json` in deps stage and `scripts/` source in build stage

## Files Changed
- `Dockerfile` (+2 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)