### PR TITLE
fix(progress): WEK-71 remove duplicate gh_automation_jobs write

### DIFF
--- a/packages/ghosthands/src/workers/progressTracker.ts
+++ b/packages/ghosthands/src/workers/progressTracker.ts
@@ -261,21 +261,9 @@ export class ProgressTracker {
       console.warn(`[ProgressTracker] Event write failed for job ${this.jobId}:`, err);
     }
 
-    // Also update progress_pct + status_message on the job row itself
-    // (this is what Supabase Realtime picks up for the frontend)
-    try {
-      await this.supabase
-        .from('gh_automation_jobs')
-        .update({
-          status_message: snapshot.description,
-          metadata: {
-            progress: snapshot,
-          },
-        })
-        .eq('id', this.jobId);
-    } catch (err) {
-      console.warn(`[ProgressTracker] Job row update failed for job ${this.jobId}:`, err);
-    }
+    // NOTE: Previously also updated gh_automation_jobs.metadata.progress here,
+    // but this was duplicate storage. gh_job_events is now the single source
+    // of truth for progress data (WEK-71 progress dedup).
   }
 
   /** Emit progress, but throttled to avoid DB write storms. */


### PR DESCRIPTION
## Summary
- **Remove duplicate write**: ProgressTracker no longer updates `gh_automation_jobs.metadata.progress` alongside `gh_job_events`
- `gh_job_events` is now the single source of truth for progress data
- VALET reads progress via `computeProgressFromEvents()` at query time

## Context
Part of WEK-71 progress dedup. The ProgressTracker was writing the same progress snapshot to both `gh_job_events` (insert) and `gh_automation_jobs.metadata` (update). The job row update was redundant since VALET now reads from `gh_job_events` directly.

## Files Changed
- `packages/ghosthands/src/workers/progressTracker.ts` — Remove `gh_automation_jobs` update block

## Test plan
- [x] GH TypeScript build passes (`bun run build`)
- [x] 836 unit tests pass (24 pre-existing failures in ECR auth/credential-injection unrelated to this change)
- [ ] Verify progress tracking works end-to-end in staging after VALET-side PR is also merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)