### PR TITLE
fix(worker): WEK-88 use forward slash in pg-boss queue names

### DIFF
--- a/packages/ghosthands/src/workers/PgBossConsumer.ts
+++ b/packages/ghosthands/src/workers/PgBossConsumer.ts
@@ -78,7 +78,7 @@ export class PgBossConsumer {
       // Queue may already exist — that's fine
     });
 
-    const targetedQueue = `${QUEUE_APPLY_JOB}:${this.workerId}`;
+    const targetedQueue = `${QUEUE_APPLY_JOB}/${this.workerId}`;
     await this.boss.createQueue(targetedQueue, queueOptions).catch(() => {
       // Queue may already exist — that's fine
     });


### PR DESCRIPTION
## Summary
- pg-boss rejects colons (`:`) in queue names — only allows alphanumeric, underscores, hyphens, periods, forward slashes
- Changed targeted queue separator from `gh_apply_job:{workerId}` to `gh_apply_job/{workerId}`
- Fixes `pg-boss error: Name can only contain alphanumeric characters, underscores, hyphens, periods, or forward slashes`

## Files Changed
- `packages/ghosthands/src/workers/PgBossConsumer.ts` — 1 line (separator `:` → `/`)

## Test plan
- [ ] Worker starts in queue mode without pg-boss errors
- [ ] VALET enqueues to `gh_apply_job/{workerId}`, GH worker picks up from same queue
- [ ] General queue `gh_apply_job` still works (no targeted routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)