### PR TITLE
feat(infra): Kasm Workspaces Docker image + deployment guide

### DIFF
--- a/Dockerfile.kasm
+++ b/Dockerfile.kasm
@@ -1,0 +1,102 @@
+# ──────────────────────────────────────────────────
+# GhostHands Kasm Workspaces Image
+#
+# Extends Kasm core desktop image with GH worker runtime.
+# Kasm provides VNC + desktop; this adds bun + Patchright + GH worker.
+#
+# Build:
+#   docker build -f Dockerfile.kasm -t ghosthands-kasm:latest .
+#
+# The image is registered in Kasm admin panel as a workspace.
+# Kasm launches sessions from this image and injects env vars at runtime.
+# ──────────────────────────────────────────────────
+
+# Stage 1: Build GH worker in a bun image (same as production Dockerfile)
+FROM oven/bun:1.2-debian AS build
+
+WORKDIR /app
+
+COPY package.json bun.lock turbo.json ./
+COPY packages/ghosthands/package.json packages/ghosthands/
+COPY scripts/package.json scripts/
+
+RUN bun install --frozen-lockfile
+
+COPY packages/ packages/
+COPY scripts/ scripts/
+COPY tsconfig.base.json ./
+
+RUN bun run build
+
+# Stage 2: Kasm desktop image with GH worker
+FROM kasmweb/core-ubuntu-noble:1.16.1
+
+USER root
+
+# Install system dependencies for Patchright/Chromium + unzip for bun installer
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    unzip \
+    ca-certificates \
+    curl \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libdbus-1-3 \
+    libxkbcommon0 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2t64 \
+    libwayland-client0 \
+    fonts-noto-color-emoji \
+    fonts-liberation \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install bun globally (to /usr/local/bin so all users can access it)
+RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash
+ENV PATH="/usr/local/bin:$PATH"
+
+# BAML vendored OpenSSL fix (same as production Dockerfile)
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs
+RUN mkdir -p /usr/local/ssl && \
+    ln -s /etc/ssl/certs/ca-certificates.crt /usr/local/ssl/cert.pem && \
+    ln -s /etc/ssl/certs /usr/local/ssl/certs
+
+# Copy built GH worker from build stage
+COPY --from=build /app/node_modules /opt/ghosthands/node_modules
+COPY --from=build /app/package.json /opt/ghosthands/
+COPY --from=build /app/packages/ghosthands/dist /opt/ghosthands/packages/ghosthands/dist
+COPY --from=build /app/packages/ghosthands/src /opt/ghosthands/packages/ghosthands/src
+COPY --from=build /app/packages/ghosthands/package.json /opt/ghosthands/packages/ghosthands/
+
+# Make GH worker directory accessible to kasm-user (uid 1000)
+RUN chown -R 1000:1000 /opt/ghosthands
+
+# Create Patchright browser cache directory (kasm-user home may not have .cache)
+RUN mkdir -p /home/kasm-user/.cache/ms-playwright && \
+    chown -R 1000:1000 /home/kasm-user/.cache
+
+# Install Patchright browser as kasm-user
+USER 1000
+RUN cd /opt/ghosthands && bunx patchright install chromium
+
+# Copy custom startup script (Kasm runs this after desktop is ready)
+USER root
+COPY scripts/kasm-startup.sh /dockerstartup/custom_startup.sh
+RUN chmod +x /dockerstartup/custom_startup.sh
+
+# Expose GH worker API port (mapped in Kasm workspace config)
+EXPOSE 3100
+
+# Kasm handles the entrypoint — custom_startup.sh runs after desktop init
+USER 1000

--- a/docs/KASM-DEPLOYMENT-GUIDE.md
+++ b/docs/KASM-DEPLOYMENT-GUIDE.md
@@ -1,0 +1,339 @@
+# Kasm Workspaces Deployment Guide
+
+**For:** DevOps, Engineering Leads
+**Last Updated:** 2026-02-21
+
+This guide documents the full process for deploying Kasm Workspaces CE with a GhostHands worker image. Follow these steps to set up a new Kasm server or register a new EC2 instance for sandbox orchestration.
+
+---
+
+## Architecture Overview
+
+```
+VALET (Fly.io)
+  └─ KasmSandboxProvider
+       └─ POST /api/public/request_kasm → Kasm CE (EC2)
+            └─ Creates Docker container with:
+                 ├─ KasmVNC desktop (browser visible to user)
+                 ├─ GH API server (port 3100)
+                 └─ GH Worker (port 3101, picks up jobs via DB)
+```
+
+Each Kasm session = isolated Docker container with a full desktop + GH worker. Environment variables are injected at session creation time by VALET.
+
+---
+
+## Prerequisites
+
+- AWS account with EC2 access
+- SSH key pair (e.g., `valet-worker.pem`)
+- VALET deployed on Fly.io (staging or prod)
+- GH source code (GHOST-HANDS repo)
+
+---
+
+## Step 1: Launch EC2 Instance
+
+**Recommended spec:**
+| Setting | Value |
+|---------|-------|
+| AMI | Ubuntu 24.04 LTS (HVM, SSD) |
+| Instance type | t3.xlarge (4 vCPU, 16 GB RAM) |
+| Storage | 100 GB gp3 EBS (encrypted) |
+| Key pair | `valet-worker` (or create new) |
+
+**Security group rules:**
+| Port | Source | Purpose |
+|------|--------|---------|
+| 443 | 0.0.0.0/0 | Kasm UI + VNC sessions |
+| 22 | Your IP | SSH admin |
+| 3100 | 0.0.0.0/0 | GH worker API (for VALET on Fly.io) |
+
+**After launch:**
+1. Allocate an Elastic IP and associate it
+2. Tag: `Name=kasm-staging`, `Project=WeKruit`, `Environment=staging`
+
+---
+
+## Step 2: Install Kasm Workspaces CE
+
+```bash
+ssh -i ~/.ssh/valet-worker.pem ubuntu@<KASM_IP>
+
+# Update system
+sudo apt update && sudo apt upgrade -y
+
+# Download and install Kasm CE 1.18.1
+cd /tmp
+curl -O https://kasm-static-content.s3.amazonaws.com/kasm_release_1.18.1.tar.gz
+tar -xf kasm_release_1.18.1.tar.gz
+sudo bash kasm_release/install.sh --accept-eula --swap-size 8192
+```
+
+Installation takes ~5 minutes. Save the admin credentials printed at the end:
+- Admin URL: `https://<KASM_IP>`
+- Admin username: `admin@kasm.local`
+- Admin password: (printed during install)
+
+---
+
+## Step 3: Configure Kasm Server Settings
+
+Connect to the Kasm Postgres database and apply these settings:
+
+```bash
+# Find the Kasm Postgres container
+sudo docker ps | grep kasmweb/postgres
+
+# Connect
+sudo docker exec -it <postgres_container> psql -U kasmapp -d kasm
+```
+
+```sql
+-- Disable aggressive image pruning (keeps custom images)
+UPDATE servers SET prune_images_mode = 'Off';
+
+-- Allow multiple simultaneous sessions
+UPDATE servers SET max_simultaneous_sessions = 5, max_simultaneous_users = 5;
+```
+
+---
+
+## Step 4: Build the GH Worker Image
+
+Clone the GH repo on the Kasm server and build:
+
+```bash
+cd /opt
+sudo git clone https://github.com/WeKruit/GHOST-HANDS.git
+cd GHOST-HANDS
+git checkout staging
+
+# Build with buildx (Docker 29+ uses containerd)
+sudo docker buildx build -f Dockerfile.kasm \
+  --output type=docker,dest=/tmp/ghosthands-kasm.tar \
+  -t ghosthands-kasm:latest .
+
+# Import into Docker's containerd store
+sudo ctr -n moby images import --all-platforms /tmp/ghosthands-kasm.tar
+
+# Verify
+sudo docker images | grep ghosthands
+```
+
+**Important:** Docker 29+ with containerd snapshotter requires the tar export + `ctr import` workflow. `docker buildx build --load` alone does NOT properly store the image.
+
+---
+
+## Step 5: Register Image in Kasm
+
+Use the Kasm admin API to register the workspace image:
+
+```bash
+# Get admin token (from Kasm Postgres)
+sudo docker exec -it <postgres_container> psql -U kasmapp -d kasm \
+  -c "SELECT token FROM users WHERE username = 'admin@kasm.local';"
+
+# Register workspace image
+curl -sk https://localhost/api/admin/create_image \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "token": "<admin_token>",
+    "target_image": {
+      "friendly_name": "GhostHands Worker",
+      "image_src": "ghosthands-kasm:latest",
+      "name": "ghosthands-kasm:latest",
+      "description": "GH browser automation worker",
+      "cores": 2,
+      "memory": 3072000000,
+      "available": true,
+      "enabled": true,
+      "image_type": "Container",
+      "run_config": "{\"hostname\":\"gh-worker\"}"
+    }
+  }'
+```
+
+Save the returned `image.image_id` — this is `KASM_DEFAULT_IMAGE_ID`.
+
+**Fix image name in DB** (if needed):
+```sql
+-- The images table `name` field MUST match the Docker tag
+UPDATE images SET name = 'ghosthands-kasm:latest', available = true
+  WHERE friendly_name = 'GhostHands Worker';
+```
+
+---
+
+## Step 6: Create API Key
+
+```bash
+# Via Kasm admin API
+curl -sk https://localhost/api/admin/add_api_key \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "token": "<admin_token>",
+    "target_api_key": {
+      "name": "valet-integration"
+    }
+  }'
+```
+
+Save `api_key` and `api_key_secret`.
+
+**Add required permissions** (connect to Kasm Postgres):
+```sql
+-- Find the group_id for the API key
+SELECT group_id FROM groups_api_keys WHERE api_id = '<api_id>';
+
+-- Add User permission (required for session management)
+INSERT INTO group_permissions (group_permission_id, permission_id, group_id, api_id)
+VALUES (gen_random_uuid(), 100, '<group_id>', '<api_id>');
+
+-- Add Users Auth Session permission (required for session auth)
+INSERT INTO group_permissions (group_permission_id, permission_id, group_id, api_id)
+VALUES (gen_random_uuid(), 352, '<group_id>', '<api_id>');
+```
+
+**Get User ID** (for session creation):
+```sql
+SELECT user_id FROM users WHERE username = 'admin@kasm.local';
+```
+
+---
+
+## Step 7: Set VALET Environment Variables
+
+```bash
+fly secrets set -a valet-api-stg \
+  KASM_API_URL="https://<KASM_IP>/api/public" \
+  KASM_API_KEY="<api_key>" \
+  KASM_API_KEY_SECRET="<api_key_secret>" \
+  KASM_DEFAULT_IMAGE_ID="<image_id>" \
+  KASM_DEFAULT_USER_ID="<user_id>" \
+  AUTOSCALE_ENABLED="false"
+```
+
+---
+
+## Step 8: Register Sandbox in VALET Database
+
+Run in Supabase SQL Editor:
+
+```sql
+INSERT INTO sandboxes (
+  id, name, environment, instance_id, instance_type,
+  public_ip, status, health_status, capacity, current_load,
+  browser_engine, machine_type, auto_stop_enabled,
+  idle_minutes_before_stop, tags, created_at, updated_at
+) VALUES (
+  gen_random_uuid(),
+  'kasm-staging-01',
+  'staging',
+  '<ec2_instance_id>',
+  'kasm',
+  '<KASM_IP>',
+  'active',
+  'healthy',
+  1,
+  0,
+  'chromium',
+  'kasm',
+  true,
+  30,
+  '{}',
+  NOW(),
+  NOW()
+)
+RETURNING id;
+```
+
+---
+
+## Step 9: Verify End-to-End
+
+Test session creation via API:
+
+```bash
+curl -sk https://<KASM_IP>/api/public/request_kasm \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "api_key": "<api_key>",
+    "api_key_secret": "<api_key_secret>",
+    "image_id": "<image_id>",
+    "user_id": "<user_id>",
+    "environment": {
+      "GH_WORKER_ID": "test-001",
+      "GH_API_PORT": "3100",
+      "DATABASE_URL": "<database_url>",
+      "GH_SERVICE_SECRET": "<gh_service_secret>",
+      ...
+    }
+  }'
+```
+
+Verify inside the container:
+```bash
+# Health checks
+docker exec <container_id> curl -s http://localhost:3100/health
+docker exec <container_id> curl -s http://localhost:3101/worker/health
+
+# Startup logs
+docker exec <container_id> cat /tmp/gh-startup.log
+docker exec <container_id> cat /tmp/gh-api.log
+docker exec <container_id> cat /tmp/gh-worker.log
+```
+
+Destroy test session:
+```bash
+curl -sk https://<KASM_IP>/api/public/destroy_kasm \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "api_key": "<api_key>",
+    "api_key_secret": "<api_key_secret>",
+    "kasm_id": "<kasm_id>",
+    "user_id": "<user_id>"
+  }'
+```
+
+---
+
+## Troubleshooting
+
+### "No resources are available"
+1. Check Docker image exists: `docker images | grep ghosthands`
+2. Check Kasm `images` table: `name` must match Docker tag, `available` must be `true`
+3. Check `prune_images_mode` is `Off` in `servers` table
+4. Re-import image if pruned: `ctr -n moby images import --all-platforms /tmp/ghosthands-kasm.tar`
+
+### "Unknown Service: custom_startup"
+The startup script crashed on execution. Check:
+1. Container logs: `docker logs <container_id>`
+2. Startup log: `docker exec <container_id> cat /tmp/gh-startup.log`
+3. Most common cause: missing env vars with `set -euo pipefail`
+
+### "Unauthorized" on session creation
+API key missing required permissions. Add permission_id 100 (User) and 352 (Users Auth Session) to `group_permissions`.
+
+### Docker build: image not in Docker store
+Docker 29 with containerd snapshotter issue. Use:
+```bash
+docker buildx build --output type=docker,dest=/tmp/image.tar -t tag .
+ctr -n moby images import --all-platforms /tmp/image.tar
+```
+
+---
+
+## Current Staging Infrastructure
+
+| Resource | Value |
+|----------|-------|
+| EC2 Instance | `i-0ce28cc3f3cd05c36` |
+| Public IP | `52.200.199.70` |
+| Security Group | `sg-0f9ac2fd4877e5e04` (kasm-staging) |
+| Kasm Admin | `admin@kasm.local` |
+| Kasm API Key | `VEtw0g1270Yu` |
+| Image ID | `3a08021231af4d6496139031be6bbe03` |
+| User ID | `c67e221f425947c398a7ec9416dca787` |
+| Sandbox DB ID | `94c6cb90-4b66-4056-b501-b4924e6f1ecd` |
+| VALET Env Vars | Set on `valet-api-stg` via `fly secrets` |

--- a/scripts/kasm-startup.sh
+++ b/scripts/kasm-startup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────
+# GhostHands Kasm Session Startup Script
+#
+# Kasm executes /dockerstartup/custom_startup.sh after the desktop is ready.
+# This script starts the GH API server and worker process.
+#
+# Environment variables are injected by Kasm at session creation time
+# (via the Kasm REST API's environment_override parameter).
+# Required: DATABASE_URL, GH_SERVICE_SECRET, GH_CREDENTIAL_KEY, etc.
+# ──────────────────────────────────────────────────
+
+LOG="/tmp/gh-startup.log"
+API_LOG="/tmp/gh-api.log"
+WORKER_LOG="/tmp/gh-worker.log"
+
+echo "[kasm-startup] $(date -u +%FT%TZ) Waiting for desktop..." | tee -a "$LOG"
+
+# Wait for Kasm desktop to be fully ready
+/usr/bin/desktop_ready
+
+echo "[kasm-startup] $(date -u +%FT%TZ) Desktop ready" | tee -a "$LOG"
+echo "[kasm-startup] GH_WORKER_ID=${GH_WORKER_ID:-not-set}" | tee -a "$LOG"
+echo "[kasm-startup] GH_API_PORT=${GH_API_PORT:-3100}" | tee -a "$LOG"
+
+# Validate required env vars
+MISSING=""
+[ -z "${DATABASE_URL:-}" ] && MISSING="$MISSING DATABASE_URL"
+[ -z "${GH_SERVICE_SECRET:-}" ] && MISSING="$MISSING GH_SERVICE_SECRET"
+
+if [ -n "$MISSING" ]; then
+    echo "[kasm-startup] WARNING: Missing env vars:$MISSING" | tee -a "$LOG"
+    echo "[kasm-startup] Services may fail to start. Attempting anyway..." | tee -a "$LOG"
+fi
+
+cd /opt/ghosthands
+
+# Start GH API server in background (port 3100)
+echo "[kasm-startup] $(date -u +%FT%TZ) Starting API server..." | tee -a "$LOG"
+bun packages/ghosthands/src/api/server.ts >> "$API_LOG" 2>&1 &
+API_PID=$!
+echo "[kasm-startup] API server PID=$API_PID" | tee -a "$LOG"
+
+# Start GH worker (foreground — Kasm monitors this process)
+echo "[kasm-startup] $(date -u +%FT%TZ) Starting worker..." | tee -a "$LOG"
+exec bun packages/ghosthands/src/workers/main.ts 2>&1 | tee -a "$WORKER_LOG"


### PR DESCRIPTION
## Summary
- **Dockerfile.kasm**: Multi-stage Docker build for Kasm Workspaces. Extends `kasmweb/core-ubuntu-noble:1.16.1` with bun, Patchright/Chromium, and the full GH worker runtime. Includes BAML OpenSSL fix, Patchright browser cache setup, and proper uid 1000 permissions.
- **scripts/kasm-startup.sh**: Custom Kasm session startup script. Runs after desktop is ready, launches both the GH API server (port 3100) and worker (port 3101). Validates required env vars and logs to `/tmp/gh-*.log` for debugging.
- **docs/KASM-DEPLOYMENT-GUIDE.md**: Complete onboarding guide covering EC2 provisioning, Kasm CE installation, Docker image building, image registration, API key setup, VALET env vars, DB sandbox record, and troubleshooting.

## Test plan
- [x] Docker image builds successfully on EC2 (Ubuntu 24.04, Docker 29 with containerd)
- [x] Image imported via `ctr -n moby images import` workflow
- [x] Kasm session created via public API with env var injection
- [x] GH API server healthy: `curl localhost:3100/health` → `{"status":"ok"}`
- [x] GH Worker healthy: `curl localhost:3101/worker/health` → `{"status":"idle","deploy_safe":true}`
- [x] Worker connects to Postgres, Redis, and registers in `gh_worker_registry`
- [x] Session destroyed cleanly via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)