### PR TITLE
feat: Magnitude on AdsPower — adapter layer with CDP connection

### DIFF
--- a/packages/ghosthands/src/adapters/index.ts
+++ b/packages/ghosthands/src/adapters/index.ts
@@ -1,0 +1,35 @@
+export type {
+  BrowserAutomationAdapter,
+  AdapterStartOptions,
+  ActionContext,
+  ActionResult,
+  TokenUsage,
+  AdapterType,
+  AdapterEvent,
+  ObservedElement,
+  LLMConfig,
+  BrowserLaunchOptions,
+} from './types';
+export { MagnitudeAdapter } from './magnitude';
+export { MockAdapter, type MockAdapterConfig } from './mock';
+
+import type { BrowserAutomationAdapter, AdapterType } from './types';
+import { MagnitudeAdapter } from './magnitude';
+import { MockAdapter } from './mock';
+
+export function createAdapter(type: AdapterType = 'magnitude'): BrowserAutomationAdapter {
+  switch (type) {
+    case 'magnitude':
+      return new MagnitudeAdapter();
+    case 'mock':
+      return new MockAdapter();
+    case 'stagehand':
+      throw new Error('Stagehand adapter not yet implemented. Install @browserbasehq/stagehand and create StagehandAdapter.');
+    case 'actionbook':
+      throw new Error('Actionbook adapter not yet implemented. Install @actionbookdev/js-sdk and create ActionbookAdapter.');
+    case 'hybrid':
+      throw new Error('Hybrid adapter not yet implemented. Requires a primary adapter + Actionbook.');
+    default:
+      throw new Error(`Unknown adapter type: ${type}`);
+  }
+}

--- a/packages/ghosthands/src/adapters/magnitude.ts
+++ b/packages/ghosthands/src/adapters/magnitude.ts
@@ -1,0 +1,139 @@
+import {
+  BrowserAgent,
+  startBrowserAgent,
+} from 'magnitude-core';
+import type { ModelUsage } from 'magnitude-core';
+import type {
+  BrowserAutomationAdapter,
+  AdapterStartOptions,
+  AdapterEvent,
+  ActionContext,
+  ActionResult,
+  TokenUsage,
+} from './types';
+import type { Page } from 'playwright';
+import type { ZodSchema } from 'zod';
+import EventEmitter from 'eventemitter3';
+
+export class MagnitudeAdapter implements BrowserAutomationAdapter {
+  readonly type = 'magnitude' as const;
+  private agent: BrowserAgent | null = null;
+  private emitter = new EventEmitter();
+  private active = false;
+  private _credentials: Record<string, string> = {};
+
+  async start(options: AdapterStartOptions): Promise<void> {
+    this.agent = await startBrowserAgent({
+      url: options.url,
+      llm: {
+        provider: options.llm.provider,
+        options: options.llm.options,
+      } as any,
+      connectors: options.connectors,
+      prompt: options.systemPrompt,
+      browser: options.cdpUrl
+        ? { cdp: options.cdpUrl }
+        : options.browserOptions as any,
+    });
+
+    // Wire Magnitude events to adapter events
+    this.agent.events.on('actionStarted', (action) => {
+      this.emitter.emit('actionStarted', { variant: action.variant });
+    });
+    this.agent.events.on('actionDone', (action) => {
+      this.emitter.emit('actionDone', { variant: action.variant });
+    });
+    this.agent.events.on('tokensUsed', (usage: ModelUsage) => {
+      const tokenUsage: TokenUsage = {
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        inputCost: usage.inputCost ?? 0,
+        outputCost: usage.outputCost ?? 0,
+      };
+      this.emitter.emit('tokensUsed', tokenUsage);
+    });
+    this.agent.events.on('thought', (reasoning) => {
+      this.emitter.emit('thought', reasoning);
+    });
+
+    this.active = true;
+  }
+
+  async act(instruction: string, context?: ActionContext): Promise<ActionResult> {
+    const start = Date.now();
+    try {
+      await this.requireAgent().act(instruction, {
+        prompt: context?.prompt,
+        data: context?.data,
+      });
+      return {
+        success: true,
+        message: `Completed: ${instruction}`,
+        durationMs: Date.now() - start,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: (error as Error).message,
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async extract<T>(instruction: string, schema: ZodSchema<T>): Promise<T> {
+    return this.requireAgent().extract(instruction, schema);
+  }
+
+  // observe() is NOT implemented for Magnitude (vision-based, no DOM discovery)
+
+  async navigate(url: string): Promise<void> {
+    await this.requireAgent().page.goto(url);
+  }
+
+  async getCurrentUrl(): Promise<string> {
+    return this.requireAgent().page.url();
+  }
+
+  async screenshot(): Promise<Buffer> {
+    const raw = await this.requireAgent().page.screenshot();
+    return Buffer.from(raw);
+  }
+
+  get page(): Page {
+    return this.requireAgent().page;
+  }
+
+  registerCredentials(creds: Record<string, string>): void {
+    this._credentials = { ...this._credentials, ...creds };
+    // magnitude-core 0.3.1 does not expose registerCredentials on BrowserAgent.
+    // Credentials are stored locally and can be accessed by custom connectors
+    // or injected into prompts as needed.
+  }
+
+  on(event: AdapterEvent, handler: (...args: any[]) => void): void {
+    this.emitter.on(event, handler);
+  }
+
+  off(event: AdapterEvent, handler: (...args: any[]) => void): void {
+    this.emitter.off(event, handler);
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  async stop(): Promise<void> {
+    if (this.agent) {
+      await this.agent.stop();
+      this.agent = null;
+    }
+    this.active = false;
+  }
+
+  private requireAgent(): BrowserAgent {
+    if (!this.agent) {
+      throw new Error('MagnitudeAdapter: not started. Call start() first.');
+    }
+    return this.agent;
+  }
+}

--- a/packages/ghosthands/src/adapters/mock.ts
+++ b/packages/ghosthands/src/adapters/mock.ts
@@ -1,0 +1,142 @@
+import type {
+  BrowserAutomationAdapter,
+  AdapterStartOptions,
+  AdapterEvent,
+  ActionContext,
+  ActionResult,
+  ObservedElement,
+} from './types';
+import type { Page } from 'playwright';
+import type { ZodSchema } from 'zod';
+import EventEmitter from 'eventemitter3';
+
+export interface MockAdapterConfig {
+  actionCount?: number;
+  totalTokens?: number;
+  costPerToken?: number;
+  failAtAction?: number;
+  failWithError?: Error;
+  extractResult?: any;
+  actionDelayMs?: number;
+}
+
+/**
+ * Mock adapter for unit/integration tests.
+ * Does NOT launch a browser -- emits fake events to simulate
+ * the same lifecycle as MagnitudeAdapter or StagehandAdapter.
+ */
+export class MockAdapter implements BrowserAutomationAdapter {
+  readonly type = 'mock' as const;
+  private emitter = new EventEmitter();
+  private config: Required<MockAdapterConfig>;
+  private active = false;
+  private _currentUrl = 'about:blank';
+
+  constructor(config: MockAdapterConfig = {}) {
+    this.config = {
+      actionCount: config.actionCount ?? 5,
+      totalTokens: config.totalTokens ?? 1000,
+      costPerToken: config.costPerToken ?? 0.000001,
+      failAtAction: config.failAtAction ?? -1,
+      failWithError: config.failWithError ?? new Error('Mock failure'),
+      extractResult: config.extractResult ?? { submitted: true },
+      actionDelayMs: config.actionDelayMs ?? 1,
+    };
+  }
+
+  async start(options: AdapterStartOptions): Promise<void> {
+    this._currentUrl = options.url ?? 'about:blank';
+    this.active = true;
+  }
+
+  async act(instruction: string, _context?: ActionContext): Promise<ActionResult> {
+    const start = Date.now();
+    const tokensPerAction = Math.floor(this.config.totalTokens / this.config.actionCount);
+    const costPerAction = tokensPerAction * this.config.costPerToken;
+
+    try {
+      for (let i = 0; i < this.config.actionCount; i++) {
+        if (this.config.failAtAction === i) {
+          throw this.config.failWithError;
+        }
+
+        this.emitter.emit('actionStarted', { variant: `mock_action_${i}` });
+        await new Promise(r => setTimeout(r, this.config.actionDelayMs));
+
+        this.emitter.emit('tokensUsed', {
+          inputTokens: tokensPerAction,
+          outputTokens: tokensPerAction,
+          inputCost: costPerAction,
+          outputCost: costPerAction,
+        });
+
+        this.emitter.emit('actionDone', { variant: `mock_action_${i}` });
+      }
+
+      return {
+        success: true,
+        message: `Mock completed: ${instruction}`,
+        durationMs: Date.now() - start,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: (error as Error).message,
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  async extract<T>(_instruction: string, _schema: ZodSchema<T>): Promise<T> {
+    return this.config.extractResult as T;
+  }
+
+  async observe(_instruction: string): Promise<ObservedElement[]> {
+    return [
+      { selector: '#mock-input', description: 'Mock input field', method: 'fill', arguments: [] },
+      { selector: '#mock-button', description: 'Mock submit button', method: 'click', arguments: [] },
+    ];
+  }
+
+  async navigate(url: string): Promise<void> {
+    this._currentUrl = url;
+  }
+
+  async getCurrentUrl(): Promise<string> {
+    return this._currentUrl;
+  }
+
+  async screenshot(): Promise<Buffer> {
+    return Buffer.from('fake-png-data');
+  }
+
+  registerCredentials(_creds: Record<string, string>): void {
+    // No-op in mock
+  }
+
+  on(event: AdapterEvent, handler: (...args: any[]) => void): void {
+    this.emitter.on(event, handler);
+  }
+
+  off(event: AdapterEvent, handler: (...args: any[]) => void): void {
+    this.emitter.off(event, handler);
+  }
+
+  get page(): Page {
+    return {
+      screenshot: async () => Buffer.from('fake-png'),
+      route: async () => {},
+      unroute: async () => {},
+      goto: async () => null,
+      url: () => this._currentUrl,
+    } as unknown as Page;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  async stop(): Promise<void> {
+    this.active = false;
+  }
+}

--- a/packages/ghosthands/src/adapters/types.ts
+++ b/packages/ghosthands/src/adapters/types.ts
@@ -1,0 +1,149 @@
+import type { Page } from 'playwright';
+import type { ZodSchema } from 'zod';
+
+/**
+ * Abstraction over browser automation engines (Magnitude, Stagehand, Actionbook).
+ *
+ * All browser interactions in GHOST-HANDS go through this interface.
+ * Only adapter implementations may import from magnitude-core or stagehand directly.
+ */
+export interface BrowserAutomationAdapter {
+  /** Adapter identifier */
+  readonly type: AdapterType;
+
+  // -- Lifecycle --
+
+  /** Initialize the adapter with browser and LLM configuration */
+  start(options: AdapterStartOptions): Promise<void>;
+
+  /** Stop the adapter, close browser connections, release resources */
+  stop(): Promise<void>;
+
+  /** Whether the adapter is currently active */
+  isActive(): boolean;
+
+  // -- Core Actions --
+
+  /** Execute a natural-language action on the current page */
+  act(instruction: string, context?: ActionContext): Promise<ActionResult>;
+
+  /** Extract structured data from the current page using a Zod schema */
+  extract<T>(instruction: string, schema: ZodSchema<T>): Promise<T>;
+
+  // -- Observation (optional) --
+
+  /**
+   * Discover interactive elements on the page without executing actions.
+   * Native to Stagehand; simulated via screenshot analysis for Magnitude;
+   * uses searchActions for Actionbook.
+   */
+  observe?(instruction: string): Promise<ObservedElement[] | undefined>;
+
+  // -- Navigation --
+
+  /** Navigate to a URL */
+  navigate(url: string): Promise<void>;
+
+  /** Get the current page URL */
+  getCurrentUrl(): Promise<string>;
+
+  // -- State --
+
+  /** Take a screenshot of the current page */
+  screenshot(): Promise<Buffer>;
+
+  /** Access the underlying browser page for escape-hatch operations */
+  get page(): Page;
+
+  // -- Credentials --
+
+  /** Register sensitive values that should not be sent to LLMs */
+  registerCredentials(creds: Record<string, string>): void;
+
+  // -- Events --
+
+  /** Subscribe to adapter lifecycle events */
+  on(event: AdapterEvent, handler: (...args: any[]) => void): void;
+  off(event: AdapterEvent, handler: (...args: any[]) => void): void;
+}
+
+// -- Types --
+
+export type AdapterType = 'magnitude' | 'stagehand' | 'actionbook' | 'hybrid' | 'mock';
+
+export type AdapterEvent =
+  | 'actionStarted'
+  | 'actionDone'
+  | 'tokensUsed'
+  | 'thought'
+  | 'error'
+  | 'progress';
+
+export interface AdapterStartOptions {
+  /** Initial URL to navigate to */
+  url?: string;
+  /** LLM configuration */
+  llm: LLMConfig;
+  /** CDP WebSocket URL for connecting to existing browser */
+  cdpUrl?: string;
+  /** Browser launch options (ignored if cdpUrl provided) */
+  browserOptions?: BrowserLaunchOptions;
+  /** Connectors to pass to the underlying agent (Magnitude-specific) */
+  connectors?: any[];
+  /** System prompt for the LLM */
+  systemPrompt?: string;
+  /** Per-application budget limit in USD */
+  budgetLimit?: number;
+}
+
+export interface ActionContext {
+  /** Additional LLM instructions for this action */
+  prompt?: string;
+  /** Data to substitute into the instruction */
+  data?: Record<string, any>;
+}
+
+export interface ActionResult {
+  /** Whether the action succeeded */
+  success: boolean;
+  /** Human-readable description of what happened */
+  message: string;
+  /** Duration in milliseconds */
+  durationMs: number;
+  /** Tokens consumed, if trackable */
+  tokensUsed?: number;
+}
+
+export interface ObservedElement {
+  /** CSS or XPath selector */
+  selector: string;
+  /** Human-readable description */
+  description: string;
+  /** Interaction method */
+  method: string;
+  /** Arguments for the method */
+  arguments: unknown[];
+}
+
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  inputCost: number;
+  outputCost: number;
+}
+
+export interface LLMConfig {
+  provider: string;
+  options: {
+    model: string;
+    apiKey?: string;
+  };
+  /** LLM roles for multi-model setups (Magnitude) */
+  roles?: ('act' | 'extract' | 'query')[];
+}
+
+export interface BrowserLaunchOptions {
+  headless?: boolean;
+  viewport?: { width: number; height: number };
+  args?: string[];
+}


### PR DESCRIPTION
## Summary

实现 Magnitude 通过 CDP 协议连接 AdsPower 反检测浏览器的 adapter 层。

- 定义 `BrowserAutomationAdapter` 接口，将所有浏览器自动化操作抽象为 `act()` / `extract()` / `navigate()` / `screenshot()`
- 实现 `MagnitudeAdapter`，封装 `magnitude-core` 的 `BrowserAgent`
- 通过 `cdpUrl` 参数支持连接外部浏览器（AdsPower、Browserbase 等）
- 实现 `MockAdapter` 用于无浏览器的单元测试
- 工厂函数 `createAdapter()` 按类型创建 adapter 实例

## Magnitude 接 AdsPower 的核心实现

**`adapters/magnitude.ts` 第 27-33 行：**

```typescript
this.agent = await startBrowserAgent({
  url: options.url,
  llm: { ... },
  browser: options.cdpUrl
    ? { cdp: options.cdpUrl }     // ← 连接 AdsPower
    : options.browserOptions,     // ← 自己启动浏览器
});
```

**`adapters/types.ts` AdapterStartOptions：**

```typescript
interface AdapterStartOptions {
  url?: string;
  llm: LLMConfig;
  cdpUrl?: string;                // ← AdsPower 返回的 WebSocket URL
  browserOptions?: BrowserLaunchOptions;  // ← cdpUrl 存在时忽略
  // ...
}
```

## 工作流程

```
AdsPower Local API                    GhostHands
──────────────────                    ──────────
POST /api/v1/browser/start
  → { ws: { puppeteer: "ws://127.0.0.1:9222/..." } }
                                      ↓
                              cdpUrl = ws://127.0.0.1:9222/...
                                      ↓
                              MagnitudeAdapter.start({ cdpUrl })
                                      ↓
                              startBrowserAgent({ browser: { cdp: cdpUrl } })
                                      ↓
                              Patchright (patched Playwright) connects via CDP
                                      ↓
                              act() / extract() / screenshot()
                              在 AdsPower 反检测浏览器内执行
```

**AdsPower 提供：** canvas/WebGL/WebRTC fingerprint masking、代理管理、浏览器 profile 隔离
**Magnitude 提供：** LLM 驱动的浏览器自动化（表单填写、导航、数据提取）
**两者通过 CDP WebSocket 解耦 — 互不感知对方实现。**

## Files changed

| 文件 | 行数 | 说明 |
|------|------|------|
| `adapters/types.ts` | 149 | `BrowserAutomationAdapter` 接口 + `cdpUrl` 字段定义 |
| `adapters/magnitude.ts` | 139 | `MagnitudeAdapter` — 核心 CDP 连接逻辑在此 |
| `adapters/mock.ts` | 142 | `MockAdapter` — 测试用 |
| `adapters/index.ts` | 35 | `createAdapter()` 工厂函数 |

## Test plan

- [ ] Review `cdpUrl` 分支逻辑是否正确传递给 `startBrowserAgent`
- [ ] Review `MockAdapter` 是否覆盖所有接口方法
- [ ] Review `types.ts` 接口定义是否完整

🤖 Generated with [Claude Code](https://claude.com/claude-code)