### PR TITLE
fix(ci): WEK-142 fix SSH key path in deploy-asg pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,6 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
-          SSH_KEY_PATH: ~/.ssh/valet-worker.pem
           SSH_USER: ubuntu
         run: |
           chmod +x scripts/deploy-to-asg.sh


### PR DESCRIPTION
## Summary

- Remove `SSH_KEY_PATH: ~/.ssh/valet-worker.pem` from CI `env:` block
- Tilde `~` is NOT expanded in GitHub Actions env values — it stays literal, causing `[ ! -f "~/.ssh/valet-worker.pem" ]` to fail
- The deploy script already defaults to `$HOME/.ssh/valet-worker.pem` at line 30, which expands correctly at shell runtime
- One-line deletion fix

## Root Cause

```yaml
# BEFORE (broken): ~ stays literal in env values
env:
  SSH_KEY_PATH: ~/.ssh/valet-worker.pem

# AFTER (fixed): script uses its own default $HOME/.ssh/valet-worker.pem
env:
  # SSH_KEY_PATH removed — script defaults to $HOME expansion
```

## Test Plan

- [ ] Merge to staging → triggers CI → deploy-asg job should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)