### PR TITLE
feat(docker): add VNC support for live browser viewing

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -29,6 +29,7 @@ services:
       - NODE_ENV=production
       - GH_ENVIRONMENT=staging
       - GH_API_PORT=3100
+      - GH_VNC_ENABLED=false
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
       - SSL_CERT_DIR=/etc/ssl/certs
     healthcheck:
@@ -86,17 +87,18 @@ services:
     command: ["bun", "packages/ghosthands/src/workers/main.ts"]
     ports:
       - "0.0.0.0:${GH_WORKER_PORT:-3101}:3101"
+      - "0.0.0.0:6080:6080"
     env_file: .env
     environment:
       - NODE_ENV=production
       - GH_ENVIRONMENT=staging
       - MAX_CONCURRENT_JOBS=${MAX_CONCURRENT_JOBS:-1}
       - GH_WORKER_PORT=3101
+      - GH_VNC_ENABLED=true
+      - GH_BROWSER_HEADLESS=false
       - DISPLAY=:99
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
       - SSL_CERT_DIR=/etc/ssl/certs
-    volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix:rw
     depends_on:
       api:
         condition: service_healthy

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────
+# GhostHands Docker Entrypoint
+#
+# Starts the VNC stack (Xvfb + x11vnc + noVNC) in the background,
+# then executes the main process (API server or worker) as PID 1.
+#
+# The VNC stack is only started if GH_VNC_ENABLED=true (default: true).
+# Set GH_VNC_ENABLED=false to skip VNC and run headless-only.
+# ──────────────────────────────────────────────────
+
+VNC_ENABLED="${GH_VNC_ENABLED:-true}"
+
+if [ "$VNC_ENABLED" = "true" ]; then
+  echo "[entrypoint] Starting VNC stack..."
+  /app/scripts/start-vnc.sh
+  export DISPLAY=:99
+  echo "[entrypoint] VNC stack ready. DISPLAY=$DISPLAY"
+else
+  echo "[entrypoint] VNC disabled (GH_VNC_ENABLED=$VNC_ENABLED)"
+fi
+
+# Execute the main process (passed as CMD arguments)
+echo "[entrypoint] Starting main process: $@"
+exec "$@"

--- a/scripts/start-vnc.sh
+++ b/scripts/start-vnc.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────
+# VNC Stack Startup
+#
+# Starts Xvfb (virtual display), x11vnc (VNC server), and noVNC (web client).
+# The browser renders on the virtual display (:99) and can be viewed
+# remotely via noVNC at http://<host>:6080/vnc.html
+#
+# Ports:
+#   :99   — X11 virtual display (Xvfb)
+#   5900  — VNC protocol (x11vnc)
+#   6080  — noVNC web client (HTTP/WebSocket)
+# ──────────────────────────────────────────────────
+
+set -e
+
+# Start Xvfb (virtual display) on :99
+echo "[vnc] Starting Xvfb on display :99 (1920x1080x24)..."
+Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
+XVFB_PID=$!
+
+# Export DISPLAY for child processes
+export DISPLAY=:99
+
+# Wait for Xvfb to be ready
+sleep 1
+
+# Verify Xvfb started
+if ! kill -0 "$XVFB_PID" 2>/dev/null; then
+  echo "[vnc] ERROR: Xvfb failed to start"
+  exit 1
+fi
+
+# Start x11vnc (VNC server) on display :99, listening on port 5900
+echo "[vnc] Starting x11vnc on display :99, port 5900..."
+x11vnc -display :99 -forever -nopw -shared -rfbport 5900 -noxdamage &
+X11VNC_PID=$!
+
+sleep 0.5
+
+if ! kill -0 "$X11VNC_PID" 2>/dev/null; then
+  echo "[vnc] ERROR: x11vnc failed to start"
+  exit 1
+fi
+
+# Start noVNC (web VNC client) — serves on port 6080, proxies to localhost:5900
+# The noVNC proxy path varies by Debian package version
+NOVNC_PROXY=""
+if [ -f /usr/share/novnc/utils/novnc_proxy ]; then
+  NOVNC_PROXY="/usr/share/novnc/utils/novnc_proxy"
+elif [ -f /usr/share/novnc/utils/launch.sh ]; then
+  NOVNC_PROXY="/usr/share/novnc/utils/launch.sh"
+else
+  # Fall back to websockify directly with noVNC web root
+  echo "[vnc] noVNC proxy script not found, using websockify directly..."
+  websockify --web /usr/share/novnc 6080 localhost:5900 &
+  NOVNC_PID=$!
+fi
+
+if [ -n "$NOVNC_PROXY" ]; then
+  echo "[vnc] Starting noVNC via $NOVNC_PROXY on port 6080..."
+  $NOVNC_PROXY --vnc localhost:5900 --listen 6080 &
+  NOVNC_PID=$!
+fi
+
+sleep 0.5
+
+if ! kill -0 "$NOVNC_PID" 2>/dev/null; then
+  echo "[vnc] WARNING: noVNC proxy may have failed to start (PID $NOVNC_PID)"
+fi
+
+echo "[vnc] VNC stack started: Xvfb :99 (PID $XVFB_PID), x11vnc :5900 (PID $X11VNC_PID), noVNC :6080 (PID $NOVNC_PID)"


### PR DESCRIPTION
## Summary
- Install Xvfb, x11vnc, noVNC, websockify in Docker runtime stage
- Add `start-vnc.sh`: starts virtual display + VNC server + noVNC web proxy on port 6080
- Add `docker-entrypoint.sh`: controlled by `GH_VNC_ENABLED` env var
- Worker runs headed mode (`GH_BROWSER_HEADLESS=false`) so browser renders on virtual display
- API container skips VNC (`GH_VNC_ENABLED=false`)
- noVNC serves on port 6080 for iframe embedding in VALET task detail UI

## How it works
1. Xvfb creates virtual display :99 (1920x1080)
2. x11vnc captures the display on VNC port 5900
3. noVNC proxies VNC → WebSocket on port 6080
4. VALET embeds `http://<ip>:6080/vnc.html` in task detail iframe
5. Browser runs in headed mode, visible through the VNC chain

## Test plan
- [ ] Docker build succeeds with new packages
- [ ] Worker container starts with VNC stack (port 6080 accessible)
- [ ] Browser renders on virtual display during job execution
- [ ] noVNC web client loads in browser iframe
- [ ] API container runs without VNC (GH_VNC_ENABLED=false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)