### PR TITLE
fix(deploy): mount Docker config for ECR auth

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -61,11 +61,13 @@ services:
       - GH_WORKER_HOST=worker
       - GH_WORKER_PORT=3101
       - GHOSTHANDS_DIR=/opt/ghosthands
+      - DOCKER_CONFIG_PATH=/docker-config/config.json
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
       - SSL_CERT_DIR=/etc/ssl/certs
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/opt/ghosthands:ro
+      - /home/ubuntu/.docker:/docker-config:ro
     deploy:
       resources:
         limits:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -65,11 +65,13 @@ services:
       - GH_WORKER_HOST=worker
       - GH_WORKER_PORT=3101
       - GHOSTHANDS_DIR=/opt/ghosthands
+      - DOCKER_CONFIG_PATH=/docker-config/config.json
       - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
       - SSL_CERT_DIR=/etc/ssl/certs
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/opt/ghosthands:ro
+      - /home/ubuntu/.docker:/docker-config:ro
     deploy:
       resources:
         limits:

--- a/scripts/lib/container-configs.ts
+++ b/scripts/lib/container-configs.ts
@@ -145,12 +145,13 @@ function buildDeployServerService(ecrImage: string, envVars: string[]): ServiceD
     config: {
       Image: ecrImage,
       Cmd: ['bun', 'scripts/deploy-server.ts'],
-      Env: [...envVars, 'GH_DEPLOY_PORT=8000'],
+      Env: [...envVars, 'GH_DEPLOY_PORT=8000', 'DOCKER_CONFIG_PATH=/docker-config/config.json'],
       HostConfig: {
         NetworkMode: 'host',
         Binds: [
           '/opt/ghosthands:/opt/ghosthands:ro',
           '/var/run/docker.sock:/var/run/docker.sock',
+          '/home/ubuntu/.docker:/docker-config:ro',
         ],
         RestartPolicy: {
           Name: 'unless-stopped',

--- a/scripts/lib/ecr-auth.ts
+++ b/scripts/lib/ecr-auth.ts
@@ -37,7 +37,7 @@ const DEFAULT_REGISTRY = process.env.ECR_REGISTRY ?? '';
  * Path to Docker config.json inside the container (mounted from host).
  * Override with DOCKER_CONFIG_PATH env var.
  */
-const DOCKER_CONFIG_PATH = process.env.DOCKER_CONFIG_PATH ?? '/root/.docker/config.json';
+const DOCKER_CONFIG_PATH = process.env.DOCKER_CONFIG_PATH ?? '/docker-config/config.json';
 
 /**
  * In-memory cached token


### PR DESCRIPTION
## Summary
- Deploy-server container couldn't pull ECR images — `EACCES: permission denied, open '/root/.docker/config.json'`
- Root cause: host Docker config (`/home/ubuntu/.docker/config.json`) was never mounted into the deploy-server container, and the default path assumed root access
- Fix: mount `/home/ubuntu/.docker` as `/docker-config:ro` and set `DOCKER_CONFIG_PATH=/docker-config/config.json` in all 3 deploy-server definitions

## Changes
| File | Change |
|------|--------|
| `scripts/lib/ecr-auth.ts` | Default path `/root/.docker/config.json` → `/docker-config/config.json` |
| `scripts/lib/container-configs.ts` | Added Docker config bind mount + env var to deploy-server |
| `docker-compose.staging.yml` | Added Docker config volume + env var to deploy-server |
| `docker-compose.prod.yml` | Added Docker config volume + env var to deploy-server |

## Test plan
- [x] Build passes (`tsc`)
- [x] 978 unit tests pass
- [ ] After merge: SSH to EC2, restart deploy-server with new compose, verify deploy works

## Note
Since auto-deploy is broken (this is the bug), after merge we need to manually restart the deploy-server on EC2 with the updated docker-compose to pick up the mount. Then subsequent deploys will work automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)