### PR TITLE
fix(deploy): use host networking for deploy-server

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,19 +46,19 @@ services:
         max-file: "3"
 
   # Deploy Server — receives deploy commands from VALET's DeployService
-  # Runs on port 8000, calls deploy.sh to execute deploys
+  # Uses host networking so it can health-check containers it creates
+  # (which also run on host network via Docker API deploys)
   deploy-server:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "scripts/deploy-server.ts"]
-    ports:
-      - "0.0.0.0:${GH_DEPLOY_PORT:-8000}:8000"
+    network_mode: host
     env_file: .env
     environment:
       - NODE_ENV=production
       - GH_DEPLOY_PORT=8000
-      - GH_API_HOST=api
+      - GH_API_HOST=localhost
       - GH_API_PORT=3100
-      - GH_WORKER_HOST=worker
+      - GH_WORKER_HOST=localhost
       - GH_WORKER_PORT=3101
       - GHOSTHANDS_DIR=/opt/ghosthands
       - DOCKER_CONFIG_PATH=/docker-config/config.json

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -50,19 +50,20 @@ services:
         max-file: "3"
 
   # Deploy Server — receives deploy commands from VALET's DeployService
+  # Uses host networking so it can health-check containers it creates
+  # (which also run on host network via Docker API deploys)
   deploy-server:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "scripts/deploy-server.ts"]
-    ports:
-      - "0.0.0.0:${GH_DEPLOY_PORT:-8000}:8000"
+    network_mode: host
     env_file: .env
     environment:
       - NODE_ENV=production
       - GH_ENVIRONMENT=staging
       - GH_DEPLOY_PORT=8000
-      - GH_API_HOST=api
+      - GH_API_HOST=localhost
       - GH_API_PORT=3100
-      - GH_WORKER_HOST=worker
+      - GH_WORKER_HOST=localhost
       - GH_WORKER_PORT=3101
       - GHOSTHANDS_DIR=/opt/ghosthands
       - DOCKER_CONFIG_PATH=/docker-config/config.json

--- a/scripts/deploy-to-asg.sh
+++ b/scripts/deploy-to-asg.sh
@@ -92,6 +92,13 @@ set -euo pipefail
 
 cd "${REMOTE_DIR}"
 
+# Pull latest compose/deploy scripts so on-disk files stay in sync
+# Detect branch from image tag: staging-<sha> → staging, <sha> → main
+GIT_BRANCH="staging"
+case "${IMAGE_TAG}" in staging-*) GIT_BRANCH="staging" ;; *) GIT_BRANCH="main" ;; esac
+echo "[remote] Pulling latest scripts from \$GIT_BRANCH..."
+git pull origin "\$GIT_BRANCH" --ff-only 2>/dev/null || echo "[remote] Git pull skipped (conflicts or not a git repo)"
+
 # ECR login
 echo "[remote] Logging into ECR..."
 aws ecr get-login-password --region "${REGION}" \


### PR DESCRIPTION
## Summary
- Deploy-server in docker-compose now uses `network_mode: host` instead of bridge network
- Changed `GH_API_HOST`/`GH_WORKER_HOST` from compose service names (`api`/`worker`) to `localhost`
- Added automatic `git pull` in `deploy-to-asg.sh` to keep on-disk compose files in sync

## Root Cause
Deploy-server ran on docker-compose's `ghosthands_default` bridge network but created new containers via Docker API with `NetworkMode: 'host'`. Health checks using `localhost` from the bridge-networked deploy-server couldn't reach host-networked containers, causing 404 "No such image" errors.

## Test plan
- [x] Typecheck passes (`bun run build`)
- [x] Tested on EC2 (44.198.167.49): deploy-server recreated with host networking
- [x] Deploy via API with mutable `staging` tag: **success** (37.9s)
- [x] Deploy via API with full SHA tag `staging-02b89b0...`: **success** (38.0s)
- [x] All 3 containers healthy post-deploy (API, Worker, Deploy-server)
- [x] Deploy-server correctly stops old compose containers and creates new host-networked ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)