### PR TITLE
fix(deploy): all services host networking + standalone cleanup

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,10 @@
 # To bootstrap a fresh EC2 instance:
 #   docker compose -f docker-compose.prod.yml up -d
 #
+# All services use host networking to match deploy-server Docker API deploys
+# (which also create containers with NetworkMode: 'host'). This prevents
+# port conflicts when both deploy paths run in sequence.
+#
 # For manual operations, use scripts/deploy.sh or deploy-server API.
 #
 # Production deployment for GhostHands API + Worker
@@ -19,8 +23,7 @@ services:
   api:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "packages/ghosthands/src/api/server.ts"]
-    ports:
-      - "0.0.0.0:${GH_API_PORT:-3100}:3100"
+    network_mode: host
     env_file: .env
     environment:
       - NODE_ENV=production
@@ -46,8 +49,6 @@ services:
         max-file: "3"
 
   # Deploy Server — receives deploy commands from VALET's DeployService
-  # Uses host networking so it can health-check containers it creates
-  # (which also run on host network via Docker API deploys)
   deploy-server:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "scripts/deploy-server.ts"]
@@ -89,8 +90,7 @@ services:
   worker:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "packages/ghosthands/src/workers/main.ts"]
-    ports:
-      - "0.0.0.0:${GH_WORKER_PORT:-3101}:3101"
+    network_mode: host
     env_file: .env
     environment:
       - NODE_ENV=production

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -7,12 +7,9 @@
 #
 # For manual operations, use scripts/deploy.sh or deploy-server API.
 #
-# Staging deployment for GhostHands — identical to prod but with staging-specific defaults
-#
-# Differences from production:
-#   - GH_ENVIRONMENT=staging (reported in health endpoints)
-#   - Deploy server bound to 0.0.0.0:8000 (for VALET access)
-#   - Lower resource limits (staging instances are smaller)
+# All services use host networking to match deploy-server Docker API deploys
+# (which also create containers with NetworkMode: 'host'). This prevents
+# port conflicts when both deploy paths run in sequence.
 #
 # Usage:
 #   ECR_IMAGE=<registry>/ghosthands:staging-<sha> docker compose -f docker-compose.staging.yml up -d
@@ -22,8 +19,7 @@ services:
   api:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "packages/ghosthands/src/api/server.ts"]
-    ports:
-      - "0.0.0.0:${GH_API_PORT:-3100}:3100"
+    network_mode: host
     env_file: .env
     environment:
       - NODE_ENV=production
@@ -50,8 +46,6 @@ services:
         max-file: "3"
 
   # Deploy Server — receives deploy commands from VALET's DeployService
-  # Uses host networking so it can health-check containers it creates
-  # (which also run on host network via Docker API deploys)
   deploy-server:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "scripts/deploy-server.ts"]
@@ -89,8 +83,7 @@ services:
   worker:
     image: ${ECR_IMAGE:-ghosthands:latest}
     command: ["bun", "packages/ghosthands/src/workers/main.ts"]
-    ports:
-      - "0.0.0.0:${GH_WORKER_PORT:-3101}:3101"
+    network_mode: host
     env_file: .env
     environment:
       - NODE_ENV=production

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -246,6 +246,16 @@ cmd_deploy() {
   fi
   docker compose -f "$COMPOSE_FILE" stop -t 35 worker 2>/dev/null || true
 
+  # Stop any standalone containers (from deploy-server Docker API deploys)
+  # These use host networking and would conflict with compose containers
+  for name in ghosthands-api ghosthands-worker ghosthands-deploy-server; do
+    if docker ps -a --format '{{.Names}}' | grep -qx "$name"; then
+      log "Removing standalone container: $name"
+      docker stop -t 10 "$name" 2>/dev/null || true
+      docker rm "$name" 2>/dev/null || true
+    fi
+  done
+
   # Restart compose services (API + default worker)
   docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
 


### PR DESCRIPTION
## Summary
- All compose services now use `network_mode: host` (not just deploy-server)
- `deploy.sh` removes standalone containers before `docker compose up` to prevent port conflicts
- Removed `ports` mappings (unnecessary with host networking)

## Root Cause
Two CI deploy paths (webhook→deploy-server + SSH→deploy.sh) conflict: webhook creates host-networked containers, then SSH's docker-compose tries to bind the same ports with bridge networking.

## Test plan
- [x] Typecheck passes
- [x] deploy-server webhook deploy tested manually on EC2 (both paths)
- [ ] CI deploy-asg re-run (pending merge)

Follows up on PR #32 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)