### PR TITLE
fix(ci): swap deploy order — ASG before VALET notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,12 +130,12 @@ jobs:
             docker push $ECR_REGISTRY/$ECR_REPOSITORY:staging
           fi
 
-  # ─── Deploy: Staging ──────────────────────────────────────────
+  # ─── Deploy: Staging (notify VALET after ASG is updated) ─────
 
   deploy-staging:
     name: Deploy Staging
     runs-on: ubuntu-latest
-    needs: [docker, test-integration]
+    needs: [docker, deploy-asg]
     if: github.event_name == 'push'
     environment: staging
     steps:
@@ -227,13 +227,13 @@ jobs:
           fi
 
   # ─── Deploy to ASG instances (SSH) ────────────────────────────
-  # After Docker push + staging notification, SSH to each running
-  # ASG instance and pull/restart the new image.
+  # FIRST: SSH to each running ASG instance and pull/restart the
+  # new image. VALET notification happens after this succeeds.
 
   deploy-asg:
     name: Deploy to ASG Fleet
     runs-on: ubuntu-latest
-    needs: [docker, deploy-staging]
+    needs: [docker, test-integration]
     if: github.event_name == 'push'
     environment: ${{ needs.docker.outputs.environment }}
     steps:
@@ -268,12 +268,12 @@ jobs:
         run: rm -f ~/.ssh/valet-worker.pem
 
   # ─── Deploy: Production ───────────────────────────────────────
-  # Only triggers on main branch pushes, after staging succeeds
+  # Only triggers on main branch pushes, after ASG is updated
 
   deploy-production:
     name: Deploy Production
     runs-on: ubuntu-latest
-    needs: [docker, deploy-staging]
+    needs: [docker, deploy-asg]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production
     steps:

--- a/packages/ghosthands/__tests__/unit/cicd-pipeline.test.ts
+++ b/packages/ghosthands/__tests__/unit/cicd-pipeline.test.ts
@@ -82,14 +82,14 @@ describe('CI/CD Workflow (ci.yml)', () => {
     expect(ci.jobs.docker.outputs).toHaveProperty('environment');
   });
 
-  test('deploy-staging depends on docker and test-integration', () => {
-    expect(ci.jobs['deploy-staging'].needs).toContain('docker');
-    expect(ci.jobs['deploy-staging'].needs).toContain('test-integration');
+  test('deploy-asg depends on docker and test-integration (runs before VALET notification)', () => {
+    expect(ci.jobs['deploy-asg'].needs).toContain('docker');
+    expect(ci.jobs['deploy-asg'].needs).toContain('test-integration');
   });
 
-  test('deploy-asg depends on docker and deploy-staging', () => {
-    expect(ci.jobs['deploy-asg'].needs).toContain('docker');
-    expect(ci.jobs['deploy-asg'].needs).toContain('deploy-staging');
+  test('deploy-staging depends on docker and deploy-asg (notifies VALET after EC2 update)', () => {
+    expect(ci.jobs['deploy-staging'].needs).toContain('docker');
+    expect(ci.jobs['deploy-staging'].needs).toContain('deploy-asg');
   });
 
   test('deploy-asg cleans up SSH key on failure', () => {
@@ -107,8 +107,8 @@ describe('CI/CD Workflow (ci.yml)', () => {
     expect(condition).toContain('push');
   });
 
-  test('deploy-production depends on deploy-staging', () => {
-    expect(ci.jobs['deploy-production'].needs).toContain('deploy-staging');
+  test('deploy-production depends on deploy-asg (notifies VALET after EC2 update)', () => {
+    expect(ci.jobs['deploy-production'].needs).toContain('deploy-asg');
   });
 });
 


### PR DESCRIPTION
## Summary

- **deploy-asg** now runs BEFORE **deploy-staging** and **deploy-production**, fixing a race condition where VALET was notified (and auto-deployed to EC2) before ASG had pulled/restarted the new containers.
- Changed `deploy-asg.needs` from `[docker, deploy-staging]` to `[docker, test-integration]`
- Changed `deploy-staging.needs` from `[docker, test-integration]` to `[docker, deploy-asg]`
- Changed `deploy-production.needs` from `[docker, deploy-staging]` to `[docker, deploy-asg]`
- Updated comments to reflect the new ordering

### New pipeline order

```
typecheck → test-unit → docker ─┐
typecheck → test-integration ───┤
                                ├→ deploy-asg → deploy-staging  (staging branch)
                                └→ deploy-asg → deploy-production (main branch)
```

No step logic was changed — only `needs` arrays and comments.

## Test plan

- [ ] Verify CI workflow YAML is valid (GitHub Actions parses it on push)
- [ ] On next staging push, confirm deploy-asg completes before deploy-staging fires
- [ ] Confirm VALET notification webhook fires after EC2 containers are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)