### PR TITLE
feat(kasm): WEK-147 exclusive VNC sessions + expanded env validation

### DIFF
--- a/Dockerfile.kasm
+++ b/Dockerfile.kasm
@@ -95,6 +95,9 @@ USER root
 COPY scripts/kasm-startup.sh /dockerstartup/custom_startup.sh
 RUN chmod +x /dockerstartup/custom_startup.sh
 
+# WEK-147: KasmVNC exclusive session config (max 1 client, disconnect others)
+COPY config/kasmvnc.yaml /etc/kasmvnc/kasmvnc.yaml
+
 # Expose GH worker API port (mapped in Kasm workspace config)
 EXPOSE 3100
 

--- a/config/kasmvnc.yaml
+++ b/config/kasmvnc.yaml
@@ -1,0 +1,4 @@
+network:
+  protocol: http
+  max_clients: 1
+  disconnect_clients: true

--- a/scripts/kasm-startup.sh
+++ b/scripts/kasm-startup.sh
@@ -27,6 +27,9 @@ echo "[kasm-startup] GH_API_PORT=${GH_API_PORT:-3100}" | tee -a "$LOG"
 MISSING=""
 [ -z "${DATABASE_URL:-}" ] && MISSING="$MISSING DATABASE_URL"
 [ -z "${GH_SERVICE_SECRET:-}" ] && MISSING="$MISSING GH_SERVICE_SECRET"
+[ -z "${GH_CREDENTIAL_KEY:-}" ] && MISSING="$MISSING GH_CREDENTIAL_KEY"
+[ -z "${SUPABASE_URL:-}" ] && MISSING="$MISSING SUPABASE_URL"
+[ -z "${ANTHROPIC_API_KEY:-}" ] && MISSING="$MISSING ANTHROPIC_API_KEY"
 
 if [ -n "$MISSING" ]; then
     echo "[kasm-startup] WARNING: Missing env vars:$MISSING" | tee -a "$LOG"


### PR DESCRIPTION
## Summary
- Add KasmVNC exclusive session config (max 1 client, disconnects others)
- Expand Kasm startup script env var validation
- Companion to VALET PR that wires Kasm into task dispatch

## Changes
- **config/kasmvnc.yaml**: New file — `max_clients: 1`, `disconnect_clients: true`
- **Dockerfile.kasm**: Copy kasmvnc.yaml into `/etc/kasmvnc/kasmvnc.yaml`
- **scripts/kasm-startup.sh**: Add validation for `GH_CREDENTIAL_KEY`, `SUPABASE_URL`, `ANTHROPIC_API_KEY`

## Test plan
- [x] `bun run build` — builds cleanly
- [ ] Manual: Build Docker image and verify KasmVNC enforces single-client sessions
- [ ] Manual: Verify startup script logs warnings for missing env vars

**Companion PR:** WeKruit/VALET — Kasm dispatch + live view UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)