### PR TITLE
feat(api): Phase 2 — browser session registry + CDP proxy

### DIFF
--- a/packages/ghosthands/src/api/server.ts
+++ b/packages/ghosthands/src/api/server.ts
@@ -15,6 +15,7 @@ import { createUsageRoutes } from './routes/usage.js';
 import { requestLoggingMiddleware, getLogger } from '../monitoring/logger.js';
 import { metricsMiddleware } from './middleware/metrics.js';
 import { createMonitoringRoutes } from './routes/monitoring.js';
+import { browserSessionRegistry } from '../workers/browserSessionRegistry.js';
 
 const { Pool } = pg;
 
@@ -79,6 +80,21 @@ export function createApp() {
   // Mount under versioned prefix
   app.route('/api/v1/gh', api);
 
+  // ─── Internal Browser Session Endpoint (service-key auth) ─────
+
+  app.get('/internal/browser-session', (c) => {
+    const serviceKey = c.req.header('X-GH-Service-Key');
+    const expectedSecret = process.env.GH_SERVICE_SECRET;
+    if (!expectedSecret) {
+      return c.json({ error: 'server_config_error', message: 'Service secret not configured' }, 500);
+    }
+    if (!serviceKey || serviceKey !== expectedSecret) {
+      return c.json({ error: 'unauthorized', message: 'Invalid service key' }, 401);
+    }
+    const snapshot = browserSessionRegistry.getPublicSnapshot();
+    return c.json(snapshot);
+  });
+
   // ─── 404 Fallback ─────────────────────────────────────────────
 
   app.notFound((c) => {
@@ -88,28 +104,130 @@ export function createApp() {
   return app;
 }
 
+/** Data attached to each CDP proxy WebSocket connection */
+export interface CdpProxyData { cdpWsUrl: string; jobId: string; cdpSocket?: WebSocket }
+
+/** Validate X-GH-Service-Key from header or query param */
+function validateServiceKey(req: Request): boolean {
+  const expectedSecret = process.env.GH_SERVICE_SECRET;
+  if (!expectedSecret) return false;
+  // Check header first, then ?key= query param (for WebSocket clients)
+  const headerKey = req.headers.get('X-GH-Service-Key');
+  if (headerKey === expectedSecret) return true;
+  const url = new URL(req.url);
+  const queryKey = url.searchParams.get('key');
+  return queryKey === expectedSecret;
+}
+
 /**
  * Start the server if this file is run directly.
- * Uses Bun.serve or Node's built-in fetch adapter.
+ * Uses Bun.serve (with WebSocket support) or Node's built-in fetch adapter.
  */
 export function startServer(port: number = 3100) {
   const app = createApp();
+  const srvLogger = getLogger({ service: 'api-server' });
 
-  getLogger().info('GhostHands API starting', { port });
+  srvLogger.info('GhostHands API starting', { port });
 
-  // Bun-native serve
+  // Bun-native serve with WebSocket CDP proxy
   if (typeof Bun !== 'undefined') {
-    return Bun.serve({
+    const server = Bun.serve<CdpProxyData>({
       port,
-      fetch: app.fetch,
+      fetch(req, server) {
+        const url = new URL(req.url);
+
+        // Handle CDP proxy WebSocket upgrade
+        if (url.pathname === '/internal/cdp-proxy') {
+          if (!validateServiceKey(req)) {
+            return new Response(JSON.stringify({ error: 'unauthorized', message: 'Invalid service key' }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          const session = browserSessionRegistry.getCurrent();
+          if (!session || !session.pausedForHuman) {
+            return new Response(JSON.stringify({ error: 'no_paused_session', message: 'No paused browser session available' }), {
+              status: 409,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          const upgraded = server.upgrade(req, {
+            data: { cdpWsUrl: session.cdpWsUrl, jobId: session.jobId },
+          });
+          if (upgraded) return undefined;
+          return new Response('WebSocket upgrade failed', { status: 500 });
+        }
+
+        // All other routes handled by Hono
+        return app.fetch(req, server);
+      },
+      websocket: {
+        open(ws) {
+          const { cdpWsUrl, jobId } = ws.data;
+          srvLogger.info('CDP proxy WebSocket opened', { jobId });
+
+          // Connect to internal Chrome CDP
+          const cdpSocket = new WebSocket(cdpWsUrl);
+
+          cdpSocket.addEventListener('open', () => {
+            srvLogger.info('CDP proxy connected to Chrome', { jobId });
+          });
+
+          cdpSocket.addEventListener('message', (event) => {
+            // Forward Chrome -> VALET
+            const data = event.data;
+            if (typeof data === 'string') {
+              ws.send(data);
+            } else if (data instanceof ArrayBuffer) {
+              ws.send(new Uint8Array(data));
+            } else if (data instanceof Blob) {
+              data.arrayBuffer().then((buf) => ws.send(new Uint8Array(buf)));
+            }
+          });
+
+          cdpSocket.addEventListener('close', () => {
+            srvLogger.info('CDP upstream closed', { jobId });
+            ws.close();
+          });
+
+          cdpSocket.addEventListener('error', (err) => {
+            srvLogger.warn('CDP upstream error', { jobId, error: String(err) });
+            ws.close();
+          });
+
+          // Store reference for message forwarding and cleanup
+          ws.data.cdpSocket = cdpSocket;
+        },
+        message(ws, msg) {
+          // Forward VALET -> Chrome CDP
+          const { cdpSocket } = ws.data;
+          if (cdpSocket?.readyState === WebSocket.OPEN) {
+            if (typeof msg === 'string') {
+              cdpSocket.send(msg);
+            } else {
+              cdpSocket.send(msg);
+            }
+          }
+        },
+        close(ws) {
+          const { cdpSocket, jobId } = ws.data;
+          srvLogger.info('CDP proxy WebSocket closed', { jobId });
+          if (cdpSocket && cdpSocket.readyState !== WebSocket.CLOSED) {
+            cdpSocket.close();
+          }
+        },
+      },
     });
+
+    return server;
   }
 
-  // Node.js fallback via @hono/node-server
-  // Users should install @hono/node-server if not using Bun
+  // Node.js fallback via @hono/node-server (no WebSocket support)
   return import('@hono/node-server').then(({ serve }) => {
     serve({ fetch: app.fetch, port });
-    getLogger().info('GhostHands API listening', { url: `http://localhost:${port}` });
+    srvLogger.info('GhostHands API listening (Node.js, no CDP proxy)', { url: `http://localhost:${port}` });
   });
 }
 

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -26,6 +26,7 @@ import { ResumeDownloader, type ResumeRef } from './resumeDownloader.js';
 import { ResumeProfileLoader } from '../db/resumeProfileLoader.js';
 import { getLogger } from '../monitoring/logger.js';
 import { AgentApplyHandler } from './taskHandlers/agentApplyHandler.js';
+import { browserSessionRegistry } from './browserSessionRegistry.js';
 
 const logger = getLogger({ service: 'job-executor' });
 
@@ -486,6 +487,29 @@ export class JobExecutor {
           // Observer is optional — don't fail the job if it can't attach
           getLogger().warn('StagehandObserver init failed', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
           observer = undefined;
+        }
+      }
+
+      // 7d. Register browser session in the in-memory registry for CDP proxy
+      {
+        const cdpWsUrl = (adapter.page?.context()?.browser() as any)?.wsEndpoint?.() as string | undefined;
+        if (cdpWsUrl) {
+          // Extract the debug port from the CDP WebSocket URL (ws://127.0.0.1:{port}/...)
+          let debugPort = 0;
+          try {
+            const parsed = new URL(cdpWsUrl);
+            debugPort = parseInt(parsed.port, 10) || 0;
+          } catch { /* best-effort */ }
+
+          browserSessionRegistry.register({
+            jobId: job.id,
+            workerId: this.workerId,
+            engine: 'chromium',
+            cdpWsUrl,
+            debugPort,
+            pausedForHuman: false,
+            updatedAt: Date.now(),
+          });
         }
       }
 
@@ -983,6 +1007,14 @@ export class JobExecutor {
       // 13. Handle awaiting_user_review vs completed
       if (taskResult.awaitingUserReview) {
         // Job paused at review page — keep browser open
+        browserSessionRegistry.setPausedForHuman(job.id, true, 'awaiting_user_review');
+        // Update page metadata for the session snapshot
+        try {
+          const pageUrl = adapter ? await adapter.getCurrentUrl() : undefined;
+          const pageTitle = adapter ? await adapter.page.title() : undefined;
+          browserSessionRegistry.updatePageMeta(job.id, pageUrl, pageTitle);
+        } catch { /* best-effort */ }
+
         await progress.setStep(ProgressStep.AWAITING_USER_REVIEW);
         await progress.flush();
 
@@ -1190,6 +1222,9 @@ export class JobExecutor {
         });
       }
     } finally {
+      // Clear browser session from registry on any exit path
+      browserSessionRegistry.clear(job.id);
+
       clearInterval(heartbeat);
       this._activeAdapter = null;
       this._executionAttemptId = null;
@@ -1529,6 +1564,10 @@ export class JobExecutor {
       await adapter.pause();
     }
 
+    // Mark session as paused for human in the browser session registry
+    browserSessionRegistry.setPausedForHuman(job.id, true, 'waiting_human');
+    browserSessionRegistry.updatePageMeta(job.id, pageUrl);
+
     await this.logJobEvent(job.id, JOB_EVENT_TYPES.HITL_PAUSED, {
       blocker_type: blockerResult.type,
       confidence: blockerResult.confidence,
@@ -1597,6 +1636,9 @@ export class JobExecutor {
           status_message: 'Resumed after human intervention',
         })
         .eq('id', job.id);
+
+      // Un-pause browser session in registry
+      browserSessionRegistry.setPausedForHuman(job.id, false);
 
       await this.logJobEvent(job.id, JOB_EVENT_TYPES.HITL_RESUMED, {
         resolution_type: result.resolutionType || 'manual',

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -309,11 +309,15 @@ export class JobExecutor {
         progress.setKasmUrl(kasmUrl);
       }
       if (job.callback_url) {
+        const sessionSnap = browserSessionRegistry.getPublicSnapshot();
         callbackNotifier.notifyRunning(
           job.id,
           job.callback_url,
           job.valet_task_id,
-          kasmUrl ? { kasm_url: kasmUrl } : undefined,
+          {
+            ...(kasmUrl ? { kasm_url: kasmUrl } : {}),
+            browser_session_available: sessionSnap.available === true,
+          },
           this.workerId,
         ).catch((err) => {
           getLogger().warn('Running callback failed', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
@@ -510,6 +514,7 @@ export class JobExecutor {
             pausedForHuman: false,
             updatedAt: Date.now(),
           });
+          progress.setBrowserSessionAvailable(true);
         }
       }
 
@@ -1579,6 +1584,7 @@ export class JobExecutor {
     // 4. Notify VALET via callback
     if (job.callback_url) {
       const costSnapshot = costTracker?.getSnapshot();
+      const hitlSessionSnap = browserSessionRegistry.getPublicSnapshot();
       callbackNotifier.notifyHumanNeeded(
         job.id,
         job.callback_url,
@@ -1603,6 +1609,8 @@ export class JobExecutor {
           action_count: costSnapshot.actionCount,
           total_tokens: costSnapshot.inputTokens + costSnapshot.outputTokens,
         } : undefined,
+        undefined, // kasmUrl — resolved inside notifyHumanNeeded
+        hitlSessionSnap.available === true,
       ).catch((err) => {
         getLogger().warn('HITL callback failed', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
       });
@@ -1646,7 +1654,8 @@ export class JobExecutor {
       });
 
       if (job.callback_url) {
-        callbackNotifier.notifyResumed(job.id, job.callback_url, job.valet_task_id, this.workerId).catch((err) => {
+        const resumeSessionSnap = browserSessionRegistry.getPublicSnapshot();
+        callbackNotifier.notifyResumed(job.id, job.callback_url, job.valet_task_id, this.workerId, undefined, resumeSessionSnap.available === true).catch((err) => {
           getLogger().warn('Resume callback failed', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
         });
       }

--- a/packages/ghosthands/src/workers/browserSessionRegistry.ts
+++ b/packages/ghosthands/src/workers/browserSessionRegistry.ts
@@ -1,0 +1,106 @@
+/**
+ * Browser Session Registry — in-memory singleton tracking the active browser session.
+ *
+ * Only one job runs per GH worker at a time, so this registry holds at most one entry.
+ * The REST endpoint (/internal/browser-session) reads the public snapshot.
+ * The CDP proxy WebSocket reads the internal cdpWsUrl (never exposed via REST).
+ */
+
+import { getLogger } from '../monitoring/logger.js';
+
+const logger = getLogger({ service: 'browser-session-registry' });
+
+export interface BrowserSession {
+  jobId: string;
+  workerId: string;
+  engine: 'chromium'; // v1 only — "adspower" future
+  cdpWsUrl: string;   // ws://127.0.0.1:{port}/devtools/browser/{id}
+  debugPort: number;
+  pausedForHuman: boolean;
+  pauseReason?: string; // "waiting_human" | "awaiting_user_review"
+  activeTargetId?: string;
+  pageUrl?: string;
+  pageTitle?: string;
+  viewport?: { width: number; height: number };
+  updatedAt: number;
+}
+
+/** Public snapshot — everything EXCEPT cdpWsUrl */
+export type BrowserSessionSnapshot = Omit<BrowserSession, 'cdpWsUrl'>;
+
+class BrowserSessionRegistry {
+  private sessions = new Map<string, BrowserSession>();
+
+  /** Register or update a browser session for a job */
+  register(session: BrowserSession): void {
+    this.sessions.set(session.jobId, { ...session, updatedAt: Date.now() });
+    logger.info('Browser session registered', { jobId: session.jobId, engine: session.engine, debugPort: session.debugPort });
+  }
+
+  /** Get the full session (including cdpWsUrl) by jobId — internal use only */
+  get(jobId: string): BrowserSession | undefined {
+    return this.sessions.get(jobId);
+  }
+
+  /** Get the single current session (one job per worker) */
+  getCurrent(): BrowserSession | undefined {
+    // There should be at most one entry; return the first
+    for (const session of this.sessions.values()) {
+      return session;
+    }
+    return undefined;
+  }
+
+  /** Update pause state for a job */
+  setPausedForHuman(jobId: string, paused: boolean, reason?: string): void {
+    const session = this.sessions.get(jobId);
+    if (!session) return;
+    session.pausedForHuman = paused;
+    session.pauseReason = paused ? reason : undefined;
+    session.updatedAt = Date.now();
+    logger.info('Browser session pause state updated', { jobId, paused, reason });
+  }
+
+  /** Update page metadata (URL, title) for a job */
+  updatePageMeta(jobId: string, url?: string, title?: string): void {
+    const session = this.sessions.get(jobId);
+    if (!session) return;
+    if (url !== undefined) session.pageUrl = url;
+    if (title !== undefined) session.pageTitle = title;
+    session.updatedAt = Date.now();
+  }
+
+  /** Remove session on job completion/failure/resume */
+  clear(jobId: string): void {
+    const deleted = this.sessions.delete(jobId);
+    if (deleted) {
+      logger.info('Browser session cleared', { jobId });
+    }
+  }
+
+  /** Return session data WITHOUT cdpWsUrl — safe for REST responses */
+  getPublicSnapshot(): (BrowserSessionSnapshot & { available: true }) | { available: false; reason: string } {
+    const session = this.getCurrent();
+    if (!session) {
+      return { available: false, reason: 'no_session' };
+    }
+    if (!session.pausedForHuman) {
+      return { available: false, reason: 'not_paused' };
+    }
+    // Engine check: v1 is chromium-only
+    if (session.engine !== 'chromium') {
+      return { available: false, reason: 'unsupported_engine' };
+    }
+
+    // Strip cdpWsUrl — NEVER include in public snapshot
+    const { cdpWsUrl: _excluded, ...publicFields } = session;
+    return {
+      available: true,
+      ...publicFields,
+      updatedAt: session.updatedAt,
+    };
+  }
+}
+
+/** Module-level singleton */
+export const browserSessionRegistry = new BrowserSessionRegistry();

--- a/packages/ghosthands/src/workers/callbackNotifier.ts
+++ b/packages/ghosthands/src/workers/callbackNotifier.ts
@@ -7,6 +7,7 @@
  */
 
 import { getLogger } from '../monitoring/logger.js';
+import { browserSessionRegistry } from './browserSessionRegistry.js';
 
 export interface InteractionInfo {
   type: string;
@@ -59,6 +60,8 @@ export interface CallbackPayload {
   } | null;
   /** Kasm session URL for live browser view (WEK-162) */
   kasm_url?: string;
+  /** Whether a browser liveview session is available for takeover */
+  browser_session_available?: boolean;
   completed_at?: string;
 }
 
@@ -131,6 +134,10 @@ export class CallbackNotifier {
       payload.kasm_url = kasmUrl;
     }
 
+    // Browser session availability — check the registry for this job
+    const sessionSnap = browserSessionRegistry.getPublicSnapshot();
+    payload.browser_session_available = sessionSnap.available === true;
+
     // Sprint 3: Mode tracking fields
     if (job.execution_mode) {
       payload.execution_mode = job.execution_mode;
@@ -162,7 +169,7 @@ export class CallbackNotifier {
     jobId: string,
     callbackUrl: string,
     valetTaskId?: string | null,
-    metadata?: { execution_mode?: string; manual_id?: string | null; kasm_url?: string },
+    metadata?: { execution_mode?: string; manual_id?: string | null; kasm_url?: string; browser_session_available?: boolean },
     workerId?: string,
   ): Promise<boolean> {
     const kasmUrl = metadata?.kasm_url || process.env.KASM_SESSION_URL;
@@ -173,6 +180,7 @@ export class CallbackNotifier {
       ...(workerId && { worker_id: workerId }),
       ...(metadata?.execution_mode && { execution_mode: metadata.execution_mode }),
       ...(kasmUrl && { kasm_url: kasmUrl }),
+      browser_session_available: metadata?.browser_session_available ?? false,
     };
     return this.sendWithRetry(callbackUrl, payload);
   }
@@ -188,6 +196,7 @@ export class CallbackNotifier {
     workerId?: string,
     cost?: { total_cost_usd: number; action_count: number; total_tokens: number },
     kasmUrl?: string,
+    browserSessionAvailable?: boolean,
   ): Promise<boolean> {
     const resolvedKasmUrl = kasmUrl || process.env.KASM_SESSION_URL;
     const payload: CallbackPayload = {
@@ -198,6 +207,7 @@ export class CallbackNotifier {
       interaction: interactionData,
       ...(cost && { cost }),
       ...(resolvedKasmUrl && { kasm_url: resolvedKasmUrl }),
+      browser_session_available: browserSessionAvailable ?? false,
     };
     return this.sendWithRetry(callbackUrl, payload);
   }
@@ -211,6 +221,7 @@ export class CallbackNotifier {
     valetTaskId?: string | null,
     workerId?: string,
     kasmUrl?: string,
+    browserSessionAvailable?: boolean,
   ): Promise<boolean> {
     const resolvedKasmUrl = kasmUrl || process.env.KASM_SESSION_URL;
     const payload: CallbackPayload = {
@@ -219,6 +230,7 @@ export class CallbackNotifier {
       status: 'resumed',
       ...(workerId && { worker_id: workerId }),
       ...(resolvedKasmUrl && { kasm_url: resolvedKasmUrl }),
+      browser_session_available: browserSessionAvailable ?? false,
     };
     return this.sendWithRetry(callbackUrl, payload);
   }

--- a/packages/ghosthands/src/workers/progressTracker.ts
+++ b/packages/ghosthands/src/workers/progressTracker.ts
@@ -80,6 +80,8 @@ export interface ProgressEventData {
   step_cost_cents?: number;
   /** Kasm session URL for live browser view (WEK-162) */
   kasm_url?: string;
+  /** Whether a browser liveview session is available for takeover */
+  browser_session_available?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -166,6 +168,7 @@ export class ProgressTracker {
   private executionMode?: 'cookbook' | 'magnitude';
   private manualId?: string;
   private kasmUrl?: string;
+  private browserSessionAvailable = false;
 
   constructor(opts: ProgressTrackerOptions) {
     this.jobId = opts.jobId;
@@ -196,6 +199,11 @@ export class ProgressTracker {
   /** Set the Kasm session URL for live view (WEK-162). */
   setKasmUrl(url: string): void {
     this.kasmUrl = url;
+  }
+
+  /** Mark whether a browser liveview session is available. */
+  setBrowserSessionAvailable(available: boolean): void {
+    this.browserSessionAvailable = available;
   }
 
   /** Called when an action starts. Infers the step and emits progress. */
@@ -239,6 +247,7 @@ export class ProgressTracker {
       ...(this.executionMode && { execution_mode: this.executionMode }),
       ...(this.manualId && { manual_id: this.manualId }),
       ...(this.kasmUrl && { kasm_url: this.kasmUrl }),
+      browser_session_available: this.browserSessionAvailable,
     };
   }
 


### PR DESCRIPTION
## Summary

Add browser session tracking and internal CDP proxy endpoints for the browser-only takeover flow. VALET will use these internal endpoints to proxy CDP commands to Chrome on behalf of users.

### New file
- **`browserSessionRegistry.ts`**: Singleton in-memory store tracking the active browser session. `getPublicSnapshot()` strips `cdpWsUrl` for REST safety. V1 is Chromium-only; non-chromium engines return `available: false`.

### Modified files
- **`server.ts`**: 
  - `GET /internal/browser-session` — REST endpoint returning public snapshot (never `cdpWsUrl`). Auth: `X-GH-Service-Key`.
  - `GET /internal/cdp-proxy` — WebSocket endpoint for bidirectional CDP frame relay. Auth: `X-GH-Service-Key` (header or `?key=` query). Pre-upgrade check: session must exist and `pausedForHuman` must be true.
- **`JobExecutor.ts`**: 
  - Register session after CDP URL discovery
  - Set `pausedForHuman` on HITL pause (both `waiting_human` and `awaiting_user_review`)
  - Clear session on resume/complete/fail (finally block)

### Security
- `cdpWsUrl` never appears in any REST response
- Both endpoints require `X-GH-Service-Key` auth
- WebSocket upgrade rejected if no paused session exists
- AdsPower fails closed: engine !== "chromium" → `available: false`

## Test plan
- [x] `bun run build` passes (tsc compiles clean)
- [x] `bun test` — 1534 pass, 29 fail (all pre-existing), 0 new failures
- [x] Grep confirms `cdpWsUrl` never in REST response path
- [ ] E2E: curl `/internal/browser-session` with service key during paused job
- [ ] E2E: WebSocket connect to `/internal/cdp-proxy` and verify CDP frame relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
