### PR TITLE
fix(build): explicitly declare @anthropic-ai/sdk in engine and ghosthands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       "name": "@wekruit/ghosthands-engine",
       "version": "0.2.1-spencer-magnitude-hand.448327c",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
         "@browserbasehq/stagehand": "3.1.0",
         "eventemitter3": "^5.0.1",
         "playwright": "npm:patchright@^1.52.0",
@@ -63,6 +64,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@actionbookdev/sdk": "^0.3.0",
+        "@anthropic-ai/sdk": "^0.39.0",
         "@browserbasehq/stagehand": "3.1.0",
         "@mastra/core": "1.7.0",
         "@mastra/pg": "1.7.0",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -41,6 +41,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "@browserbasehq/stagehand": "3.1.0",
     "eventemitter3": "^5.0.1",
     "playwright": "npm:patchright@^1.52.0"

--- a/packages/ghosthands/package.json
+++ b/packages/ghosthands/package.json
@@ -34,6 +34,7 @@
     },
     "dependencies": {
         "@actionbookdev/sdk": "^0.3.0",
+        "@anthropic-ai/sdk": "^0.39.0",
         "@browserbasehq/stagehand": "3.1.0",
         "@mastra/core": "1.7.0",
         "@mastra/pg": "1.7.0",


### PR DESCRIPTION
## Summary
- add explicit `@anthropic-ai/sdk` dependency in `packages/engine`
- add explicit `@anthropic-ai/sdk` dependency in `packages/ghosthands`
- regenerate `bun.lock`

## Validation
- `bun install`
- `bun run build` (no `@anthropic-ai/sdk` missing-module errors; remaining failures are existing Bun typing issues)
