### PR TITLE
fix(docker): include engine workspace manifest for frozen lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY package.json bun.lock turbo.json ./
 
 # Copy package.json for workspace resolution
 COPY packages/ghosthands/package.json packages/ghosthands/
+COPY packages/engine/package.json packages/engine/
 COPY scripts/package.json scripts/
 
 # Copy patches for patchedDependencies (e.g. stagehand)


### PR DESCRIPTION
## Problem
Docker build stage runs `bun install --frozen-lockfile` after copying only a subset of workspace manifests. Since `packages/engine/package.json` was not present, Bun attempted lockfile changes and failed with:

`lockfile had changes, but lockfile is frozen`

## Fix
- Copy `packages/engine/package.json` before `bun install --frozen-lockfile`
- This keeps workspace resolution consistent with committed `bun.lock` in Docker build context

## Validation
- Reproduced failure in a minimal Docker-context file set without engine manifest
- Re-ran the same setup with engine manifest present and `bun install --frozen-lockfile` succeeds
- `bun install --frozen-lockfile` succeeds in repo worktree
