### PR TITLE
feat(ghosthands): inject managed anthropic client config

### DIFF
--- a/packages/ghosthands/__tests__/unit/workers/formFillerClientConfig.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/formFillerClientConfig.test.ts
@@ -39,6 +39,7 @@ describe('formFiller Anthropic client config', () => {
       baseURL: 'https://valet.example.com/api/v1/local-workers/inference',
       defaultHeaders: {
         Authorization: 'Bearer should-be-ignored',
+        'x-api-key': 'should-be-ignored',
         'x-local-worker-session': 'session-token',
       },
     });

--- a/packages/ghosthands/__tests__/unit/workers/formFillerClientConfig.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/formFillerClientConfig.test.ts
@@ -23,4 +23,32 @@ describe('formFiller Anthropic client config', () => {
   it('falls back to Anthropic env defaults when no explicit config is supplied', () => {
     expect(buildAnthropicClientOptions()).toBeUndefined();
   });
+
+  it('rejects non-http Anthropic base URLs', () => {
+    expect(() =>
+      buildAnthropicClientOptions({
+        apiKey: 'managed-runtime-token',
+        baseURL: 'file:///tmp/evil',
+      }),
+    ).toThrow('Anthropic client baseURL must use http or https');
+  });
+
+  it('drops disallowed default headers', () => {
+    const options = buildAnthropicClientOptions({
+      apiKey: 'managed-runtime-token',
+      baseURL: 'https://valet.example.com/api/v1/local-workers/inference',
+      defaultHeaders: {
+        Authorization: 'Bearer should-be-ignored',
+        'x-local-worker-session': 'session-token',
+      },
+    });
+
+    expect(options).toEqual({
+      apiKey: 'managed-runtime-token',
+      baseURL: 'https://valet.example.com/api/v1/local-workers/inference',
+      defaultHeaders: {
+        'x-local-worker-session': 'session-token',
+      },
+    });
+  });
 });

--- a/packages/ghosthands/__tests__/unit/workers/formFillerClientConfig.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/formFillerClientConfig.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'bun:test';
+import { buildAnthropicClientOptions } from '../../../src/workers/taskHandlers/formFiller';
+
+describe('formFiller Anthropic client config', () => {
+  it('prefers explicit proxy-backed client config when provided', () => {
+    const options = buildAnthropicClientOptions({
+      apiKey: 'managed-runtime-token',
+      baseURL: 'https://valet.example.com/api/v1/local-workers/anthropic',
+      defaultHeaders: {
+        'x-local-worker-session': 'session-token',
+      },
+    });
+
+    expect(options).toEqual({
+      apiKey: 'managed-runtime-token',
+      baseURL: 'https://valet.example.com/api/v1/local-workers/anthropic',
+      defaultHeaders: {
+        'x-local-worker-session': 'session-token',
+      },
+    });
+  });
+
+  it('falls back to Anthropic env defaults when no explicit config is supplied', () => {
+    expect(buildAnthropicClientOptions()).toBeUndefined();
+  });
+});

--- a/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
@@ -27,6 +27,7 @@ import { buildAnswerDecisionsFromFieldAnswers, normalizeExtractedQuestions, reco
 import type { NormalizedQuestionDraft } from '../../context/QuestionNormalizer.js';
 import type { AnswerDecision, AnswerMode, QuestionOutcome, QuestionSnapshot } from '../../context/types.js';
 import type { WorkdayUserProfile } from './workday/workdayTypes.js';
+import type { AnthropicClientConfig } from './types.js';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -92,13 +93,6 @@ export interface FillFormOptions {
   forceMagnitude?: boolean;
   observers?: FillObservers;
   anthropicClientConfig?: AnthropicClientConfig;
-}
-
-export interface AnthropicClientConfig {
-  apiKey?: string;
-  authToken?: string;
-  baseURL?: string;
-  defaultHeaders?: Record<string, string>;
 }
 
 interface GenerateResult {
@@ -1382,23 +1376,59 @@ function trimOptionalString(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+const DISALLOWED_ANTHROPIC_DEFAULT_HEADERS = new Set([
+  'authorization',
+  'content-length',
+  'host',
+]);
+
+function normalizeAnthropicBaseURL(value: string | undefined): string | undefined {
+  const trimmed = trimOptionalString(value);
+  if (!trimmed) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error('Anthropic client baseURL must be an absolute http(s) URL');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Anthropic client baseURL must use http or https');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Anthropic client baseURL must not include embedded credentials');
+  }
+
+  parsed.hash = '';
+  return parsed.toString().replace(/\/+$/, '');
+}
+
 export function buildAnthropicClientOptions(
   clientConfig?: AnthropicClientConfig,
 ): ConstructorParameters<typeof Anthropic>[0] | undefined {
   if (!clientConfig) return undefined;
 
+  const apiKey = trimOptionalString(clientConfig.apiKey);
+  const authToken = trimOptionalString(clientConfig.authToken);
+  const baseURL = normalizeAnthropicBaseURL(clientConfig.baseURL);
+
   const defaultHeaders = clientConfig.defaultHeaders
     ? Object.fromEntries(
         Object.entries(clientConfig.defaultHeaders).filter(
-          ([key, value]) => key.trim().length > 0 && typeof value === 'string' && value.trim().length > 0,
+          ([key, value]) =>
+            key.trim().length > 0 &&
+            !DISALLOWED_ANTHROPIC_DEFAULT_HEADERS.has(key.trim().toLowerCase()) &&
+            typeof value === 'string' &&
+            value.trim().length > 0,
         ),
       )
     : undefined;
 
   const options = {
-    ...(trimOptionalString(clientConfig.apiKey) ? { apiKey: trimOptionalString(clientConfig.apiKey) } : {}),
-    ...(trimOptionalString(clientConfig.authToken) ? { authToken: trimOptionalString(clientConfig.authToken) } : {}),
-    ...(trimOptionalString(clientConfig.baseURL) ? { baseURL: trimOptionalString(clientConfig.baseURL) } : {}),
+    ...(apiKey ? { apiKey } : {}),
+    ...(authToken ? { authToken } : {}),
+    ...(baseURL ? { baseURL } : {}),
     ...(defaultHeaders && Object.keys(defaultHeaders).length > 0 ? { defaultHeaders } : {}),
   };
 

--- a/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
@@ -1380,6 +1380,7 @@ const DISALLOWED_ANTHROPIC_DEFAULT_HEADERS = new Set([
   'authorization',
   'content-length',
   'host',
+  'x-api-key',
 ]);
 
 function normalizeAnthropicBaseURL(value: string | undefined): string | undefined {

--- a/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
@@ -3479,7 +3479,11 @@ export async function fillFormOnPage(
     } else {
       // Heuristic-only path — use legacy generateAnswers
       console.log('[formFiller] Using legacy generateAnswers (heuristic path)…');
-      const genResult = await generateAnswers(llmFields, profileText);
+      const genResult = await generateAnswers(
+        llmFields,
+        profileText,
+        opts?.anthropicClientConfig,
+      );
       answers = { ...genResult.answers };
       Object.assign(fieldIdMap, genResult.fieldIdToKey);
       result.llmCalls++;
@@ -3668,7 +3672,11 @@ export async function fillFormOnPage(
       }
 
       // Generate actual fill answers for unseen fields via proven legacy path
-      const extraResult = await generateAnswers(unseen, profileText);
+      const extraResult = await generateAnswers(
+        unseen,
+        profileText,
+        opts?.anthropicClientConfig,
+      );
       Object.assign(answers, extraResult.answers);
       Object.assign(fieldIdMap, extraResult.fieldIdToKey);
       result.llmCalls++;

--- a/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
@@ -91,6 +91,14 @@ export interface FillObservers {
 export interface FillFormOptions {
   forceMagnitude?: boolean;
   observers?: FillObservers;
+  anthropicClientConfig?: AnthropicClientConfig;
+}
+
+export interface AnthropicClientConfig {
+  apiKey?: string;
+  authToken?: string;
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
 }
 
 interface GenerateResult {
@@ -1368,8 +1376,41 @@ async function discoverDropdownOptions(page: Page, fields: FormField[]): Promise
 
 // ── LLM answer generation ────────────────────────────────────
 
-async function generateAnswers(fields: FormField[], profileText: string): Promise<GenerateResult> {
-  const client = new Anthropic();
+function trimOptionalString(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function buildAnthropicClientOptions(
+  clientConfig?: AnthropicClientConfig,
+): ConstructorParameters<typeof Anthropic>[0] | undefined {
+  if (!clientConfig) return undefined;
+
+  const defaultHeaders = clientConfig.defaultHeaders
+    ? Object.fromEntries(
+        Object.entries(clientConfig.defaultHeaders).filter(
+          ([key, value]) => key.trim().length > 0 && typeof value === 'string' && value.trim().length > 0,
+        ),
+      )
+    : undefined;
+
+  const options = {
+    ...(trimOptionalString(clientConfig.apiKey) ? { apiKey: trimOptionalString(clientConfig.apiKey) } : {}),
+    ...(trimOptionalString(clientConfig.authToken) ? { authToken: trimOptionalString(clientConfig.authToken) } : {}),
+    ...(trimOptionalString(clientConfig.baseURL) ? { baseURL: trimOptionalString(clientConfig.baseURL) } : {}),
+    ...(defaultHeaders && Object.keys(defaultHeaders).length > 0 ? { defaultHeaders } : {}),
+  };
+
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
+async function generateAnswers(
+  fields: FormField[],
+  profileText: string,
+  clientConfig?: AnthropicClientConfig,
+): Promise<GenerateResult> {
+  const client = new Anthropic(buildAnthropicClientOptions(clientConfig));
   const profileEvidence = parseProfileEvidence(profileText);
 
   // Disambiguate duplicate field names by appending "#2", "#3", etc.
@@ -3355,7 +3396,7 @@ export async function fillFormOnPage(
     if (usedNewPipeline) {
       // 6c-i. Generate actual fill answers via proven legacy path
       console.log('[formFiller] Asking LLM for answers…');
-      const genResult = await generateAnswers(llmFields, profileText);
+      const genResult = await generateAnswers(llmFields, profileText, opts?.anthropicClientConfig);
       answers = { ...genResult.answers };
       Object.assign(fieldIdMap, genResult.fieldIdToKey);
       result.llmCalls++;

--- a/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
@@ -2043,6 +2043,7 @@ IMPORTANT: Do NOT select, clear, or retype any already-filled fields.`,
           true,
           costTracker,
           pageContext,
+          llmClientConfig,
         );
       }
 

--- a/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
@@ -405,6 +405,7 @@ export class SmartApplyHandler implements TaskHandler {
               stuckEscalate,
               ctx.costTracker,
               pageContext,
+              ctx.llmClientConfig,
             );
 
             if (result === 'review') {
@@ -1978,6 +1979,7 @@ IMPORTANT: Do NOT select, clear, or retype any already-filled fields.`,
     forceEscalate = false,
     costTracker?: CostTracker,
     pageContext?: PageContextService,
+    llmClientConfig?: TaskContext['llmClientConfig'],
   ): Promise<'navigated' | 'review' | 'complete'> {
     const MAX_DEPTH = 3;
 
@@ -2001,6 +2003,7 @@ IMPORTANT: Do NOT select, clear, or retype any already-filled fields.`,
       if (escalate) console.log(`[SmartApply] Escalating to MagnitudeHand (${forceEscalate ? 'stuck escalation' : `retry ${_depth}/${MAX_DEPTH}`})`);
       const fillResult = await fillFormOnPage(adapter.page, adapter, profileText, resumePath, {
         forceMagnitude: escalate,
+        anthropicClientConfig: llmClientConfig?.anthropic,
         observers: pageContext
           ? {
               onQuestionsNormalized: async (questions, opts) => pageContext.syncQuestions(questions, opts),
@@ -2086,7 +2089,17 @@ IMPORTANT: Do NOT select, clear, or retype any already-filled fields.`,
         // Pass null for resumePath on retries — resume was already uploaded on first attempt.
         // Workday replaces the file input after processing, creating a fresh one for "add another file",
         // so re-passing resumePath would cause a duplicate upload.
-        return this.fillPage(adapter, config, null, profileText, _depth + 1, false, costTracker, pageContext);
+        return this.fillPage(
+          adapter,
+          config,
+          null,
+          profileText,
+          _depth + 1,
+          false,
+          costTracker,
+          pageContext,
+          llmClientConfig,
+        );
       }
 
       // Verify page changed
@@ -2112,7 +2125,17 @@ IMPORTANT: Do NOT select, clear, or retype any already-filled fields.`,
       const scrollAfterClick = await adapter.page.evaluate(() => window.scrollY);
       if (Math.abs(scrollAfterClick - scrollBeforeClick) > 50) {
         console.log(`[SmartApply] Clicked Next — page auto-scrolled to unfilled fields. Re-filling.`);
-        return this.fillPage(adapter, config, null, profileText, _depth + 1, false, costTracker, pageContext);
+        return this.fillPage(
+          adapter,
+          config,
+          null,
+          profileText,
+          _depth + 1,
+          false,
+          costTracker,
+          pageContext,
+          llmClientConfig,
+        );
       }
 
       console.log(`[SmartApply] Clicked Next but page unchanged.`);

--- a/packages/ghosthands/src/workers/taskHandlers/types.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/types.ts
@@ -44,12 +44,7 @@ export interface TaskContext {
   credentials: Record<string, string> | null;
   dataPrompt: string;
   llmClientConfig?: {
-    anthropic?: {
-      apiKey?: string;
-      authToken?: string;
-      baseURL?: string;
-      defaultHeaders?: Record<string, string>;
-    };
+    anthropic?: AnthropicClientConfig;
   };
   /** Local file path to the downloaded resume, if a resume_ref was provided */
   resumeFilePath?: string | null;
@@ -66,6 +61,13 @@ export interface TaskContext {
     timeoutSeconds?: number;
     metadata?: Record<string, unknown>;
   }) => Promise<{ resumed: boolean }>;
+}
+
+export interface AnthropicClientConfig {
+  apiKey?: string;
+  authToken?: string;
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
 }
 
 export interface TaskResult {

--- a/packages/ghosthands/src/workers/taskHandlers/types.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/types.ts
@@ -43,6 +43,14 @@ export interface TaskContext {
   progress: ProgressTracker;
   credentials: Record<string, string> | null;
   dataPrompt: string;
+  llmClientConfig?: {
+    anthropic?: {
+      apiKey?: string;
+      authToken?: string;
+      baseURL?: string;
+      defaultHeaders?: Record<string, string>;
+    };
+  };
   /** Local file path to the downloaded resume, if a resume_ref was provided */
   resumeFilePath?: string | null;
   /** Optional email verification automation service (per-user Gmail API). */


### PR DESCRIPTION
## Summary
- allow SmartApply task contexts to pass explicit Anthropic client config into `formFiller`
- build Anthropic client options from injected proxy-backed config while preserving env fallback behavior
- add unit coverage for the explicit client-config path

## Testing
- `bun test packages/ghosthands/__tests__/unit/workers/formFillerClientConfig.test.ts`
- `bun x tsc --noEmit -p packages/ghosthands/tsconfig.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
