### PR TITLE
feat: add application reports for tracking worker submissions

### DIFF
--- a/docs/APPLICATION-REPORT-PLAN.md
+++ b/docs/APPLICATION-REPORT-PLAN.md
@@ -405,7 +405,7 @@ VALET can then call `GET /valet/reports/:jobId` to fetch the full report.
 | `src/events/JobEventTypes.ts` | **MODIFY** | Add `REPORT_GENERATED: 'report_generated'` event type |
 | `__tests__/unit/reportBuilder.test.ts` | **CREATE** | Unit tests for report builder |
 | `__tests__/integration/applicationReport.test.ts` | **CREATE** | Integration test for the full flow |
-| `docs/VALET-INTEGRATION-CONTRACT.md` | **MODIFY** | Document new endpoints and report schema |
+| `docs/VALET-APPLICATION-REPORTS-TODO.md` | **CREATE** | Handoff document for VALET frontend integration |
 
 ---
 

--- a/docs/APPLICATION-REPORT-PLAN.md
+++ b/docs/APPLICATION-REPORT-PLAN.md
@@ -1,0 +1,519 @@
+# Application Report Feature — Implementation Plan
+
+**Author:** Claude (with Spencer)
+**Date:** 2026-03-08
+**Status:** Planning
+**Branch:** TBD (suggest `feature/application-reports`)
+
+---
+
+## 1. Problem Statement
+
+After GhostHands completes a job application, users have no structured way to see **what the worker actually submitted** — which fields were filled, with what values, which resume was used, and whether any answers were low-confidence guesses.
+
+Currently, the data exists scattered across:
+- `gh_job_page_contexts.page_context` (deeply nested JSONB, designed for debugging)
+- `gh_automation_jobs.result_data.context_report` (only surfaces problematic fields)
+- `gh_job_events` (action-level audit trail, not field-centric)
+
+None of these are queryable in a VALET-friendly way.
+
+**Goal:** Create a clean, flat `gh_application_reports` table that stores a per-job report of every field the worker filled, accessible via a new API endpoint for VALET UI to display.
+
+---
+
+## 2. Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Storage approach | New `gh_application_reports` table | Clean API surface for VALET, indexed, RLS-ready |
+| Field visibility | No redaction of user's own data (phone, address) | User needs to verify what was submitted |
+| Sensitive fields | Redact passwords, SSNs, tokens only | Use existing `SENSITIVE_FIELD_RE` pattern from `finalization.ts` |
+| Scope | All job types (generic) | Future-proof, not just `smart_apply` |
+| Granularity | Flat list of field→value pairs | Per-page breakdown not needed per Spencer |
+| Backfill | Fresh start only | No public users yet, old data inconsistent |
+| Resume info | Filename/ref only | VALET can resolve the display name from resume ID |
+| Data source | PageContextSession (primary) + FillResult (fallback) | PageContext has richest data; FillResult covers non-PageContext handlers |
+
+---
+
+## 3. Data Sources Available at Finalization
+
+### 3.1 PageContextSession (Primary — Smart Apply with PageContext)
+
+At finalization time, `session.pages[*].questions[*]` contains every `QuestionRecord`:
+
+```typescript
+interface QuestionRecord {
+  questionKey: string;
+  promptText: string;           // "What is your first name?"
+  currentValue?: string;        // DOM value after fill
+  lastAnswer?: string;          // Answer that was submitted
+  questionType: QuestionType;   // 'text' | 'select' | 'email' | ...
+  source: QuestionSource;       // 'dom' | 'llm' | 'magnitude' | 'manual'
+  answerMode?: AnswerMode;      // 'profile_backed' | 'best_effort_guess' | ...
+  state: QuestionState;         // 'filled' | 'verified' | 'failed' | ...
+  required: boolean;
+  resolutionConfidence: number;
+  sectionLabel?: string;
+}
+```
+
+**Key insight:** `buildContextReport()` iterates ALL questions but only surfaces problems. Successfully filled/verified fields are accessible but not reported. We extract them ourselves.
+
+### 3.2 FillResult (Fallback — handlers without PageContext)
+
+`fillFormOnPage()` returns:
+```typescript
+interface FillResult {
+  questionOutcomes?: QuestionOutcome[];  // { questionKey, state, currentValue, source, confidence }
+  questionSnapshots?: QuestionSnapshot[]; // { questionKey, promptText, questionType, ... }
+  answerDecisions?: AnswerDecision[];     // { questionKey, answer, confidence, source, answerMode }
+}
+```
+
+Can be joined: `questionSnapshots` (field labels) + `answerDecisions` (planned values) + `questionOutcomes` (final status).
+
+### 3.3 Job Record
+
+- `job.target_url` → application URL
+- `job.input_data.user_data` → user profile sent
+- `job.resume_ref` → resume reference (filename/path)
+- `job.valet_task_id` → links to VALET task
+- `job.metadata` → platform detection, etc.
+
+### 3.4 Cost Snapshot
+
+- `finalCost.totalCost`, `finalCost.actionCount`, `finalCost.inputTokens`, `finalCost.outputTokens`
+
+---
+
+## 4. Database Schema
+
+### 4.1 Migration: `026_gh_application_reports.sql`
+
+```sql
+-- Migration 026: Application reports — structured record of what the worker submitted
+--
+-- Stores a per-job flat report of every field filled during an application,
+-- queryable by VALET UI for the Application Tracker feature.
+-- Data is populated during job finalization from PageContextSession.
+
+CREATE TABLE IF NOT EXISTS gh_application_reports (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id        UUID NOT NULL REFERENCES gh_automation_jobs(id) ON DELETE CASCADE,
+  user_id       UUID NOT NULL,
+  valet_task_id TEXT,
+
+  -- Application metadata
+  job_url       TEXT NOT NULL,
+  company_name  TEXT,
+  job_title     TEXT,
+  platform      TEXT,
+
+  -- Resume used
+  resume_ref    TEXT,
+
+  -- What the worker submitted (core payload)
+  -- Array of { prompt_text, value, question_type, source, answer_mode, confidence, required }
+  fields_submitted JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Summary counts
+  total_fields       INTEGER NOT NULL DEFAULT 0,
+  fields_filled      INTEGER NOT NULL DEFAULT 0,
+  fields_failed      INTEGER NOT NULL DEFAULT 0,
+  fields_unresolved  INTEGER NOT NULL DEFAULT 0,
+
+  -- Submission outcome
+  status         TEXT NOT NULL DEFAULT 'completed',
+  submitted      BOOLEAN NOT NULL DEFAULT false,
+  result_summary TEXT,
+
+  -- Cost
+  llm_cost_cents INTEGER,
+  action_count   INTEGER,
+  total_tokens   INTEGER,
+
+  -- Screenshots
+  screenshot_urls JSONB DEFAULT '[]'::jsonb,
+
+  -- Timestamps
+  started_at    TIMESTAMPTZ,
+  completed_at  TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gh_app_reports_job
+  ON gh_application_reports(job_id);
+
+CREATE INDEX IF NOT EXISTS idx_gh_app_reports_user
+  ON gh_application_reports(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gh_app_reports_valet_task
+  ON gh_application_reports(valet_task_id)
+  WHERE valet_task_id IS NOT NULL;
+
+-- RLS
+ALTER TABLE gh_application_reports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on gh_application_reports"
+  ON gh_application_reports FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+-- DOWN (rollback — commented)
+-- DROP TABLE IF EXISTS gh_application_reports;
+```
+
+### 4.2 `fields_submitted` JSONB Shape
+
+Each element in the array:
+
+```typescript
+interface SubmittedField {
+  prompt_text: string;       // "First Name", "Years of Experience"
+  value: string;             // "John", "5"
+  question_type: string;     // "text", "select", "email", etc.
+  source: string;            // "dom", "magnitude", "llm", "manual"
+  answer_mode?: string;      // "profile_backed", "best_effort_guess", etc.
+  confidence: number;        // 0-1
+  required: boolean;
+  section_label?: string;    // "Personal Information", "Work History"
+  state: string;             // "verified", "filled"
+}
+```
+
+---
+
+## 5. Implementation Steps
+
+### Step 1: Migration File
+
+**File:** `packages/ghosthands/src/db/migrations/026_gh_application_reports.sql`
+
+Create the table as specified in Section 4.1 above.
+
+### Step 2: Report Builder Utility
+
+**New file:** `packages/ghosthands/src/workers/reportBuilder.ts`
+
+This module extracts filled field data from the PageContextSession and builds the report payload.
+
+```typescript
+// Key exports:
+export interface ApplicationReportData {
+  job_id: string;
+  user_id: string;
+  valet_task_id?: string;
+  job_url: string;
+  company_name?: string;
+  job_title?: string;
+  platform?: string;
+  resume_ref?: string;
+  fields_submitted: SubmittedField[];
+  total_fields: number;
+  fields_filled: number;
+  fields_failed: number;
+  fields_unresolved: number;
+  status: string;
+  submitted: boolean;
+  result_summary?: string;
+  llm_cost_cents?: number;
+  action_count?: number;
+  total_tokens?: number;
+  screenshot_urls?: string[];
+  started_at?: string;
+  completed_at?: string;
+}
+
+export interface SubmittedField {
+  prompt_text: string;
+  value: string;
+  question_type: string;
+  source: string;
+  answer_mode?: string;
+  confidence: number;
+  required: boolean;
+  section_label?: string;
+  state: string;
+}
+
+// Main function — extracts from PageContextSession
+export function buildApplicationReport(
+  job: AutomationJob,
+  session: PageContextSession | null,
+  costSnapshot: CostSnapshot,
+  taskResult: TaskResult,
+  screenshotUrls: string[],
+): ApplicationReportData;
+
+// Fallback — extracts from FillResult when no PageContext
+export function buildReportFromFillResult(
+  job: AutomationJob,
+  fillResult: FillResult,
+  costSnapshot: CostSnapshot,
+  taskResult: TaskResult,
+  screenshotUrls: string[],
+): ApplicationReportData;
+```
+
+**Logic for `buildApplicationReport()`:**
+
+1. Iterate `session.pages[*].questions[*]`
+2. For each question where `state === 'filled' || state === 'verified'`:
+   - Extract `promptText`, `lastAnswer || currentValue`, `questionType`, `source`, `answerMode`, `resolutionConfidence`, `required`, `sectionLabel`
+   - Apply sensitive field redaction using `SENSITIVE_FIELD_RE`
+3. Also include `state === 'failed'` fields (with empty value) so user sees what failed
+4. Count totals: `total_fields`, `fields_filled` (verified+filled), `fields_failed`, `fields_unresolved`
+5. Extract `company_name` and `job_title` from job URL or `input_data` if available
+6. Return `ApplicationReportData`
+
+### Step 3: Integrate into Finalization
+
+**File:** `packages/ghosthands/src/workers/finalization.ts`
+
+**Injection point:** After `resultData` is assembled (after current line ~405), before the flush-failure check.
+
+Add a new helper function:
+
+```typescript
+async function writeApplicationReport(
+  supabase: SupabaseClient,
+  job: AutomationJob,
+  pageContext: PageContextService | undefined,
+  costSnapshot: CostSnapshot,
+  taskResult: TaskResult,
+  screenshotUrls: string[],
+  status: 'completed' | 'failed' | 'awaiting_review',
+  resultSummary?: string,
+): Promise<void> {
+  try {
+    // Get the session from pageContext if available
+    // Build report using buildApplicationReport() or buildReportFromFillResult()
+    // Insert into gh_application_reports
+    await supabase.from('gh_application_reports').upsert([reportData], {
+      onConflict: 'job_id',
+    });
+  } catch (err) {
+    // Best-effort — never fail the job over reporting
+    logger.warn('Failed to write application report', {
+      jobId: job.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+```
+
+**Call sites in `finalizeHandlerResult()`:**
+
+1. **Awaiting review path** (after line ~378): Write report with `status: 'awaiting_review'`
+2. **Failure path** (after line ~445): Write report with `status: 'failed'`
+3. **Success path** (after line ~497): Write report with `status: 'completed'`
+
+### Step 4: Pass Session to Report Builder
+
+**Problem:** `finalizeHandlerResult()` currently calls `flushPageContext()` which returns a `ContextReport` (summary only), not the full session.
+
+**Solution:** Modify the `flushPageContext` helper to also return the session data we need, OR access the PageContextSession before flushing.
+
+Two approaches:
+
+**Approach A (Preferred):** Extract filled fields BEFORE flushing, by reading from the PageContextService. Add a new method to `PageContextService`:
+
+```typescript
+// In PageContextService interface:
+getAllFilledFields(): Promise<SubmittedField[]>;
+```
+
+This iterates `this.session.pages[*].questions[*]` and returns the flat list.
+
+**Approach B:** Modify `flushPageContext()` to return the full session alongside the report. Less clean.
+
+### Step 5: API Endpoint
+
+**File:** `packages/ghosthands/src/api/routes/valet.ts`
+
+Add a new route:
+
+```typescript
+// GET /valet/reports/:jobId — Fetch application report for a job
+valet.get('/reports/:jobId', rateLimitMiddleware(), async (c) => {
+  const jobId = c.req.param('jobId');
+
+  const { data, error } = await supabase
+    .from('gh_application_reports')
+    .select('*')
+    .eq('job_id', jobId)
+    .single();
+
+  if (error || !data) {
+    return c.json({ error: 'Report not found' }, 404);
+  }
+
+  return c.json({ report: data });
+});
+
+// GET /valet/reports/user/:userId — List all reports for a user
+valet.get('/reports/user/:userId', rateLimitMiddleware(), async (c) => {
+  const userId = c.req.param('userId');
+  const limit = parseInt(c.req.query('limit') || '50');
+  const offset = parseInt(c.req.query('offset') || '0');
+
+  const { data, error } = await supabase
+    .from('gh_application_reports')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    return c.json({ error: 'Failed to fetch reports' }, 500);
+  }
+
+  return c.json({ reports: data, count: data?.length || 0 });
+});
+```
+
+**Note:** The `pool` (pg.Pool) is already available in the route factory. We may use either raw SQL via `pool.query()` or the Supabase client — follow whichever pattern the existing status endpoint uses.
+
+### Step 6: Include Report URL in Callback
+
+**File:** `packages/ghosthands/src/workers/finalization.ts`
+
+After writing the report, include a `report_available: true` flag in the callback payload's `result_data` so VALET knows to fetch it:
+
+```typescript
+resultData.report_available = true;
+```
+
+VALET can then call `GET /valet/reports/:jobId` to fetch the full report.
+
+---
+
+## 6. Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/db/migrations/026_gh_application_reports.sql` | **CREATE** | New migration for the table |
+| `src/workers/reportBuilder.ts` | **CREATE** | Report builder utility (extract fields, build payload) |
+| `src/workers/finalization.ts` | **MODIFY** | Add `writeApplicationReport()` call in all 3 finalization paths |
+| `src/context/PageContextService.ts` | **MODIFY** | Add `getAllFilledFields()` method to interface + implementation |
+| `src/context/NoopPageContextService.ts` | **MODIFY** | Add noop `getAllFilledFields()` |
+| `src/api/routes/valet.ts` | **MODIFY** | Add `GET /reports/:jobId` and `GET /reports/user/:userId` |
+| `src/events/JobEventTypes.ts` | **MODIFY** | Add `REPORT_GENERATED: 'report_generated'` event type |
+| `__tests__/unit/reportBuilder.test.ts` | **CREATE** | Unit tests for report builder |
+| `__tests__/integration/applicationReport.test.ts` | **CREATE** | Integration test for the full flow |
+| `docs/VALET-INTEGRATION-CONTRACT.md` | **MODIFY** | Document new endpoints and report schema |
+
+---
+
+## 7. Testing Strategy
+
+### 7.1 Unit Tests (`reportBuilder.test.ts`)
+
+1. **Build report from PageContextSession** — mock session with various question states, verify flat field extraction
+2. **Sensitive field redaction** — verify passwords/SSNs redacted, phone/address preserved
+3. **Empty session** — no pages → empty fields_submitted, zero counts
+4. **Mixed states** — verified + filled + failed + skipped → correct counts and filtering
+5. **Fallback from FillResult** — when no PageContext, verify report built from questionOutcomes + snapshots
+
+### 7.2 Integration Tests (`applicationReport.test.ts`)
+
+1. **Full finalization flow** — mock job + taskResult + pageContext → verify row written to `gh_application_reports`
+2. **API endpoint** — insert mock report → GET /valet/reports/:jobId → verify response shape
+3. **User listing** — insert multiple reports → GET /valet/reports/user/:userId → verify pagination
+4. **Best-effort resilience** — simulate DB write failure → verify job finalization still succeeds
+5. **Upsert idempotency** — call finalization twice for same job → verify single row (upsert)
+
+### 7.3 Manual Smoke Test
+
+1. Run migration: `bun src/scripts/run-migration.ts 026`
+2. Trigger a test job application
+3. Verify `gh_application_reports` row exists with populated `fields_submitted`
+4. Call `GET /api/v1/gh/valet/reports/:jobId` and verify response
+
+---
+
+## 8. Edge Cases & Considerations
+
+| Edge Case | Handling |
+|-----------|----------|
+| Job has no PageContext (old handlers) | Fall back to FillResult data if available; otherwise write report with empty fields_submitted |
+| Job fails before any fields are filled | Write report with status='failed', empty fields, zero counts |
+| Job is awaiting_review then later completes | Upsert (onConflict: job_id) updates the existing row |
+| fields_submitted JSONB is very large (100+ fields) | Unlikely for job applications; no size concern |
+| Report write fails | Best-effort — logged and swallowed, job status unaffected |
+| Multiple finalization paths (handler vs side-effects) | Only `finalizeHandlerResult()` writes reports, not `finalizeHandlerSideEffects()` |
+| AgentApplyHandler (no formFiller) | Will have empty fields_submitted until agent mode captures field data |
+
+---
+
+## 9. Sequence Diagram
+
+```
+JobExecutor
+  │
+  ├── handler.execute() → TaskResult
+  │
+  ├── finalizeHandlerResult()
+  │     │
+  │     ├── captureAndUpload() → screenshotUrls
+  │     ├── saveBrowserSession()
+  │     ├── costTracker.getSnapshot() → finalCost
+  │     ├── saveFreshSessionCookies()
+  │     ├── persist final_mode + cost metadata
+  │     │
+  │     ├── flushPageContext() → contextReport
+  │     ├── build resultData (taskResult.data + cost + context_report)
+  │     │
+  │     ├── ★ NEW: writeApplicationReport()          ◄── INJECTION POINT
+  │     │     ├── pageContext.getAllFilledFields()
+  │     │     ├── buildApplicationReport()
+  │     │     └── supabase.upsert('gh_application_reports')
+  │     │
+  │     ├── update gh_automation_jobs (status, result_data)
+  │     ├── logEvent('job_completed')
+  │     ├── recordCostBestEffort()
+  │     └── fireCallbackBestEffort() → VALET
+  │
+  └── cleanup
+```
+
+---
+
+## 10. VALET Integration Notes
+
+After this feature ships on the GH side, VALET needs to:
+
+1. **Query the new endpoint** — `GET /api/v1/gh/valet/reports/:jobId`
+2. **List user reports** — `GET /api/v1/gh/valet/reports/user/:userId`
+3. **Display in Application Tracker UI** — render `fields_submitted` as a table/list
+4. **Resolve resume name** — use `resume_ref` to look up the user's resume display name
+
+A separate VALET TODO document will be created after implementation (see Section 12).
+
+---
+
+## 11. Implementation Order
+
+1. **Migration** — create table (can be done first, no code dependency)
+2. **Report builder** — pure utility, fully unit-testable in isolation
+3. **PageContextService.getAllFilledFields()** — small interface addition
+4. **Finalization integration** — wire report builder into finalization flow
+5. **API endpoints** — expose data to VALET
+6. **Tests** — unit + integration
+7. **Contract doc update** — update VALET-INTEGRATION-CONTRACT.md
+8. **VALET TODO doc** — handoff document for VALET agent
+
+---
+
+## 12. VALET Handoff TODO (Created After Implementation)
+
+A `docs/VALET-APPLICATION-REPORTS-TODO.md` will be created containing:
+- New API endpoints with request/response examples
+- `fields_submitted` JSONB schema
+- Resume ref resolution guidance
+- UI rendering suggestions (table columns, status badges)
+- Example queries for the Application Tracker feature

--- a/docs/VALET-APPLICATION-REPORTS-TODO.md
+++ b/docs/VALET-APPLICATION-REPORTS-TODO.md
@@ -3,7 +3,7 @@
 **For:** VALET repo Claude agent
 **Date:** 2026-03-08
 **GH Branch:** `feature/application-reports` (merged into staging)
-**Context:** GhostHands now stores a structured report of every field the worker filled during a job application. This document describes the new API endpoints, data schema, and exactly where/how to integrate in VALET.
+**Context:** GhostHands now writes a structured report of every field the worker filled during a job application into the shared Supabase database. VALET should query this table directly (no GH API calls needed for reads). This document describes the table schema and how to integrate the Application Tracker UI.
 
 ---
 
@@ -18,124 +18,97 @@ After every job completes (or fails / goes to awaiting_review), GhostHands write
 
 ---
 
-## Where to Add Code in VALET
+## How to Read Reports (Direct Supabase Query)
 
-The GhostHands integration layer lives in:
+VALET and GhostHands share the same Supabase database. **VALET should query `gh_application_reports` directly** — there are no GH API endpoints for report reads. GhostHands only writes to this table.
 
-```
-apps/api/src/modules/ghosthands/
-├── ghosthands.client.ts    ← Add new methods here (getApplicationReport, listUserReports)
-├── ghosthands.types.ts     ← Add new types here (GHApplicationReport, GHSubmittedField, etc.)
-└── ghosthands.webhook.ts   ← No changes needed (callbacks unchanged)
-```
+### Get Report for a Single Job
 
-### Auth & Request Pattern
-
-All requests use the existing pattern in `ghosthands.client.ts`:
-- **Base URL:** `GHOSTHANDS_API_URL` env var (already configured, default `http://localhost:3100`)
-- **Auth header:** `X-GH-Service-Key: {GH_SERVICE_SECRET}` (already used by all other methods)
-- **Full path prefix:** `{GHOSTHANDS_API_URL}/api/v1/gh/valet/reports/...`
-
-Follow the exact same `fetch()` pattern used by existing methods like `getJobStatus(jobId)`.
-
----
-
-## New API Endpoints
-
-Base URL: `{GHOSTHANDS_API_URL}/api/v1/gh/valet`
-
-### 1. Get Report for a Single Job
-
-```
-GET /valet/reports/:jobId
+```typescript
+const { data: report } = await supabase
+  .from('gh_application_reports')
+  .select('*')
+  .eq('job_id', jobId)
+  .single();
 ```
 
-**Response (200):**
+### List All Reports for a User (Paginated)
+
+```typescript
+const { data: reports, count } = await supabase
+  .from('gh_application_reports')
+  .select('*', { count: 'exact' })
+  .eq('user_id', userId)
+  .order('created_at', { ascending: false })
+  .range(offset, offset + limit - 1);
+```
+
+### Example Row Shape
+
 ```json
 {
-  "report": {
-    "id": "uuid",
-    "job_id": "uuid",
-    "user_id": "uuid",
-    "valet_task_id": "vt-789",
-    "job_url": "https://mycompany.wd5.myworkdayjobs.com/en-US/External/job/apply",
-    "company_name": "mycompany",
-    "job_title": null,
-    "platform": "workday",
-    "resume_ref": "resumes/resume-abc.pdf",
-    "fields_submitted": [
-      {
-        "prompt_text": "First Name",
-        "value": "John",
-        "question_type": "text",
-        "source": "dom",
-        "answer_mode": "profile_backed",
-        "confidence": 0.95,
-        "required": true,
-        "section_label": "Personal Information",
-        "state": "verified"
-      },
-      {
-        "prompt_text": "Years of Experience",
-        "value": "5",
-        "question_type": "select",
-        "source": "llm",
-        "answer_mode": "best_effort_guess",
-        "confidence": 0.7,
-        "required": true,
-        "section_label": null,
-        "state": "filled"
-      }
-    ],
-    "total_fields": 15,
-    "fields_filled": 13,
-    "fields_failed": 1,
-    "fields_unresolved": 1,
-    "status": "completed",
-    "submitted": true,
-    "result_summary": "Application submitted successfully",
-    "llm_cost_cents": 5,
-    "action_count": 10,
-    "total_tokens": 1500,
-    "screenshot_urls": ["https://s3.amazonaws.com/..."],
-    "started_at": "2026-03-08T10:00:00Z",
-    "completed_at": "2026-03-08T10:02:30Z",
-    "created_at": "2026-03-08T10:02:30Z",
-    "updated_at": "2026-03-08T10:02:30Z"
-  }
+  "id": "uuid",
+  "job_id": "uuid",
+  "user_id": "uuid",
+  "valet_task_id": "vt-789",
+  "job_url": "https://mycompany.wd5.myworkdayjobs.com/en-US/External/job/apply",
+  "company_name": "mycompany",
+  "job_title": null,
+  "platform": "workday",
+  "resume_ref": "resumes/resume-abc.pdf",
+  "fields_submitted": [
+    {
+      "prompt_text": "First Name",
+      "value": "John",
+      "question_type": "text",
+      "source": "dom",
+      "answer_mode": "profile_backed",
+      "confidence": 0.95,
+      "required": true,
+      "section_label": "Personal Information",
+      "state": "verified"
+    },
+    {
+      "prompt_text": "Years of Experience",
+      "value": "5",
+      "question_type": "select",
+      "source": "llm",
+      "answer_mode": "best_effort_guess",
+      "confidence": 0.7,
+      "required": true,
+      "section_label": null,
+      "state": "filled"
+    }
+  ],
+  "total_fields": 15,
+  "fields_filled": 13,
+  "fields_failed": 1,
+  "fields_unresolved": 1,
+  "status": "completed",
+  "submitted": true,
+  "result_summary": "Application submitted successfully",
+  "llm_cost_cents": 5,
+  "action_count": 10,
+  "total_tokens": 1500,
+  "screenshot_urls": ["https://s3.amazonaws.com/..."],
+  "started_at": "2026-03-08T10:00:00Z",
+  "completed_at": "2026-03-08T10:02:30Z",
+  "created_at": "2026-03-08T10:02:30Z",
+  "updated_at": "2026-03-08T10:02:30Z"
 }
 ```
 
-**Response (404):**
-```json
-{ "error": "not_found", "message": "Report not found" }
-```
+---
 
-### 2. List All Reports for a User
+## RLS Note
 
-```
-GET /valet/reports/user/:userId?limit=50&offset=0
-```
-
-**Query params:**
-- `limit` — 1–100, default 50
-- `offset` — default 0
-
-**Response (200):**
-```json
-{
-  "reports": [ /* array of report objects, same shape as above */ ],
-  "count": 42
-}
-```
-
-> **Note:** `count` is the **total** number of reports for the user (not the page size). Use it with `limit`/`offset` to build pagination controls (e.g., "Page 1 of 3").
+The table currently only has a `service_role` RLS policy. For VALET to query via the Supabase client with an authenticated user, you need to add an RLS policy. Either:
+- Use the `service_role` client (bypasses RLS) for server-side queries, OR
+- Add an authenticated user read policy: `CREATE POLICY "Users can read own reports" ON gh_application_reports FOR SELECT TO authenticated USING (user_id = auth.uid());`
 
 ---
 
-## TypeScript Types to Add
-
-Add these to `ghosthands.types.ts`:
+## TypeScript Types
 
 ```typescript
 export interface GHSubmittedField {
@@ -177,32 +150,6 @@ export interface GHApplicationReport {
   created_at: string;
   updated_at: string;
 }
-
-export interface GHGetReportResponse {
-  report: GHApplicationReport;
-}
-
-export interface GHListReportsResponse {
-  reports: GHApplicationReport[];
-  count: number; // total count for the user (not page size)
-}
-```
-
----
-
-## Client Methods to Add
-
-Add these to `ghosthands.client.ts`, following the same pattern as `getJobStatus()`:
-
-```typescript
-async getApplicationReport(jobId: string): Promise<GHGetReportResponse | null> {
-  // GET /api/v1/gh/valet/reports/:jobId
-  // Returns null on 404 (report not found)
-}
-
-async listUserReports(userId: string, limit = 50, offset = 0): Promise<GHListReportsResponse> {
-  // GET /api/v1/gh/valet/reports/user/:userId?limit=X&offset=Y
-}
 ```
 
 ---
@@ -236,10 +183,10 @@ The `resume_ref` field contains the storage path (e.g., `resumes/resume-abc.pdf`
 
 ## VALET Implementation Checklist
 
-### Backend (`apps/api/src/modules/ghosthands/`)
-- [ ] Add `GHSubmittedField`, `GHApplicationReport`, `GHGetReportResponse`, `GHListReportsResponse` types to `ghosthands.types.ts`
-- [ ] Add `getApplicationReport(jobId)` method to `ghosthands.client.ts`
-- [ ] Add `listUserReports(userId, limit?, offset?)` method to `ghosthands.client.ts`
+### Backend
+- [ ] Add `GHSubmittedField` and `GHApplicationReport` types (see TypeScript Types section above)
+- [ ] Create a service/helper that queries `gh_application_reports` via Supabase (see query examples above)
+- [ ] Handle RLS: either use service_role client or add an authenticated user read policy
 - [ ] Resolve `resume_ref` to user-facing resume name via VALET's `resumes` table
 - [ ] Cache report data if needed (reports are immutable once status is `completed` — but may update from `awaiting_review` → `completed`)
 
@@ -258,7 +205,7 @@ The `resume_ref` field contains the storage path (e.g., `resumes/resume-abc.pdf`
 - [ ] Show screenshots (clickable thumbnails)
 - [ ] Show resume used (resolved display name)
 - [ ] Filter/sort applications by: date, company, platform, status
-- [ ] Pagination controls using `count` (total) with `limit`/`offset`
+- [ ] Pagination controls using Supabase `count: 'exact'` for total
 
 ### Visual Indicators
 - **State badges:**
@@ -284,4 +231,3 @@ The `resume_ref` field contains the storage path (e.g., `resumes/resume-abc.pdf`
 - When a job transitions from `awaiting_review` → `completed`, the report is updated via upsert (same `job_id`).
 - Sensitive fields (passwords, SSNs, tokens) are automatically redacted to `[REDACTED]`. User PII like phone numbers and addresses are NOT redacted since the user needs to verify them.
 - The `company_name` is best-effort extracted from the URL (works well for Workday, Greenhouse, Lever — may be null for unknown ATS platforms).
-- Both endpoints are rate-limited (same middleware as other valet routes).

--- a/docs/VALET-APPLICATION-REPORTS-TODO.md
+++ b/docs/VALET-APPLICATION-REPORTS-TODO.md
@@ -1,0 +1,185 @@
+# VALET Integration: Application Reports — TODO
+
+**For:** VALET repo Claude agent
+**Date:** 2026-03-08
+**GH Branch:** `feature/application-reports` (merged into staging)
+**Context:** GhostHands now stores a structured report of every field the worker filled during a job application. This document describes the new API endpoints and data schema so VALET can integrate the Application Tracker UI.
+
+---
+
+## What GhostHands Now Provides
+
+After every job completes (or fails / goes to awaiting_review), GhostHands writes a row to `gh_application_reports` containing:
+- Company name, job URL, platform (workday, greenhouse, etc.)
+- Resume reference used
+- **A flat JSON array of every field the worker filled** — field label, value submitted, field type, source (DOM/LLM/Magnitude), confidence score, required/optional, fill state
+- Summary counts (total fields, filled, failed, unresolved)
+- Submission status, cost, screenshots, timestamps
+
+---
+
+## New API Endpoints
+
+Base URL: `{GH_API_URL}/api/v1/gh/valet`
+
+### 1. Get Report for a Single Job
+
+```
+GET /valet/reports/:jobId
+```
+
+**Response (200):**
+```json
+{
+  "report": {
+    "id": "uuid",
+    "job_id": "uuid",
+    "user_id": "uuid",
+    "valet_task_id": "vt-789",
+    "job_url": "https://mycompany.wd5.myworkdayjobs.com/en-US/External/job/apply",
+    "company_name": "mycompany",
+    "job_title": null,
+    "platform": "workday",
+    "resume_ref": "resumes/resume-abc.pdf",
+    "fields_submitted": [
+      {
+        "prompt_text": "First Name",
+        "value": "John",
+        "question_type": "text",
+        "source": "dom",
+        "answer_mode": "profile_backed",
+        "confidence": 0.95,
+        "required": true,
+        "section_label": "Personal Information",
+        "state": "verified"
+      },
+      {
+        "prompt_text": "Years of Experience",
+        "value": "5",
+        "question_type": "select",
+        "source": "llm",
+        "answer_mode": "best_effort_guess",
+        "confidence": 0.7,
+        "required": true,
+        "section_label": null,
+        "state": "filled"
+      }
+    ],
+    "total_fields": 15,
+    "fields_filled": 13,
+    "fields_failed": 1,
+    "fields_unresolved": 1,
+    "status": "completed",
+    "submitted": true,
+    "result_summary": "Application submitted successfully",
+    "llm_cost_cents": 5,
+    "action_count": 10,
+    "total_tokens": 1500,
+    "screenshot_urls": ["https://s3.amazonaws.com/..."],
+    "started_at": "2026-03-08T10:00:00Z",
+    "completed_at": "2026-03-08T10:02:30Z",
+    "created_at": "2026-03-08T10:02:30Z",
+    "updated_at": "2026-03-08T10:02:30Z"
+  }
+}
+```
+
+**Response (404):**
+```json
+{ "error": "not_found", "message": "Report not found" }
+```
+
+### 2. List All Reports for a User
+
+```
+GET /valet/reports/user/:userId?limit=50&offset=0
+```
+
+**Query params:**
+- `limit` — max 100, default 50
+- `offset` — default 0
+
+**Response (200):**
+```json
+{
+  "reports": [ /* array of report objects, same shape as above */ ],
+  "count": 12
+}
+```
+
+---
+
+## `fields_submitted` Schema
+
+Each element in the `fields_submitted` JSONB array:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `prompt_text` | string | The field label shown to the worker (e.g., "First Name", "Do you require sponsorship?") |
+| `value` | string | What was submitted. Passwords/SSNs are `[REDACTED]`. Phone/address kept visible. |
+| `question_type` | string | One of: `text`, `textarea`, `email`, `tel`, `url`, `number`, `date`, `file`, `select`, `radio`, `checkbox`, `unknown` |
+| `source` | string | How the field was filled: `dom` (direct JS), `llm` (AI planned), `magnitude` (GUI agent), `manual` (human) |
+| `answer_mode` | string? | Strategy used: `profile_backed` (from user profile), `best_effort_guess` (AI guessed), `default_decline` (declined optional), `system_attachment` (file upload) |
+| `confidence` | number | 0-1 confidence score. 0.95+ = high confidence, 0.7-0.95 = moderate, <0.7 = low |
+| `required` | boolean | Whether the field was marked required by the ATS |
+| `section_label` | string? | Form section name if detected (e.g., "Personal Information", "Work History") |
+| `state` | string | Final state: `verified` (confirmed correct), `filled` (filled but unverified), `failed` (attempted but failed), `uncertain`, `planned`, `attempted` |
+
+---
+
+## Resume Reference Resolution
+
+The `resume_ref` field contains the storage path (e.g., `resumes/resume-abc.pdf`). This is NOT the user-facing filename. VALET should:
+1. Parse the resume ID from the path
+2. Look up the resume record in the VALET `resumes` table to get the display name
+3. Show the display name in the UI (e.g., "Software Engineer Resume.pdf")
+
+---
+
+## VALET Implementation Checklist
+
+### Backend
+- [ ] Add a service/helper to call `GET /valet/reports/:jobId` from GH API
+- [ ] Add a service/helper to call `GET /valet/reports/user/:userId` from GH API
+- [ ] Cache report data if needed (reports are immutable after creation)
+- [ ] Resolve `resume_ref` to user-facing resume name
+
+### Frontend (Application Tracker UI)
+- [ ] Create Application Tracker page/component (similar to Tsenta screenshot)
+- [ ] Display list of applications with: company, status, date, field count
+- [ ] Detail view: show all `fields_submitted` as a table with columns:
+  - Field Name (`prompt_text`)
+  - Value Submitted (`value`)
+  - Type (`question_type`)
+  - Confidence badge (green >=0.9, yellow 0.7-0.9, red <0.7)
+  - Required indicator
+- [ ] Show summary stats: total fields, filled, failed, unresolved
+- [ ] Show cost info: `llm_cost_cents`, `action_count`
+- [ ] Show screenshots (clickable thumbnails)
+- [ ] Show resume used (resolved display name)
+- [ ] Filter/sort applications by: date, company, platform, status
+
+### Visual Indicators
+- **State badges:**
+  - `verified` → green checkmark
+  - `filled` → blue filled circle
+  - `failed` → red X
+  - `uncertain` / other → yellow warning
+- **Confidence:**
+  - >= 0.9 → green
+  - 0.7 - 0.9 → yellow/orange
+  - < 0.7 → red
+- **Answer mode:**
+  - `profile_backed` → "From profile" label
+  - `best_effort_guess` → "AI guess" warning label
+  - `default_decline` → "Declined" label
+
+---
+
+## Notes
+
+- Reports are written best-effort — if the DB write fails, the job still completes normally. A small percentage of jobs may not have reports.
+- The `status` field on the report mirrors the job status: `completed`, `failed`, or `awaiting_review`.
+- When a job transitions from `awaiting_review` → `completed`, the report is updated via upsert (same `job_id`).
+- Sensitive fields (passwords, SSNs, tokens) are automatically redacted to `[REDACTED]`. User PII like phone numbers and addresses are NOT redacted since the user needs to verify them.
+- The `company_name` is best-effort extracted from the URL (works well for Workday, Greenhouse, Lever — may be null for unknown ATS platforms).

--- a/docs/VALET-APPLICATION-REPORTS-TODO.md
+++ b/docs/VALET-APPLICATION-REPORTS-TODO.md
@@ -3,7 +3,7 @@
 **For:** VALET repo Claude agent
 **Date:** 2026-03-08
 **GH Branch:** `feature/application-reports` (merged into staging)
-**Context:** GhostHands now stores a structured report of every field the worker filled during a job application. This document describes the new API endpoints and data schema so VALET can integrate the Application Tracker UI.
+**Context:** GhostHands now stores a structured report of every field the worker filled during a job application. This document describes the new API endpoints, data schema, and exactly where/how to integrate in VALET.
 
 ---
 
@@ -18,9 +18,31 @@ After every job completes (or fails / goes to awaiting_review), GhostHands write
 
 ---
 
+## Where to Add Code in VALET
+
+The GhostHands integration layer lives in:
+
+```
+apps/api/src/modules/ghosthands/
+├── ghosthands.client.ts    ← Add new methods here (getApplicationReport, listUserReports)
+├── ghosthands.types.ts     ← Add new types here (GHApplicationReport, GHSubmittedField, etc.)
+└── ghosthands.webhook.ts   ← No changes needed (callbacks unchanged)
+```
+
+### Auth & Request Pattern
+
+All requests use the existing pattern in `ghosthands.client.ts`:
+- **Base URL:** `GHOSTHANDS_API_URL` env var (already configured, default `http://localhost:3100`)
+- **Auth header:** `X-GH-Service-Key: {GH_SERVICE_SECRET}` (already used by all other methods)
+- **Full path prefix:** `{GHOSTHANDS_API_URL}/api/v1/gh/valet/reports/...`
+
+Follow the exact same `fetch()` pattern used by existing methods like `getJobStatus(jobId)`.
+
+---
+
 ## New API Endpoints
 
-Base URL: `{GH_API_URL}/api/v1/gh/valet`
+Base URL: `{GHOSTHANDS_API_URL}/api/v1/gh/valet`
 
 ### 1. Get Report for a Single Job
 
@@ -96,20 +118,96 @@ GET /valet/reports/user/:userId?limit=50&offset=0
 ```
 
 **Query params:**
-- `limit` — max 100, default 50
+- `limit` — 1–100, default 50
 - `offset` — default 0
 
 **Response (200):**
 ```json
 {
   "reports": [ /* array of report objects, same shape as above */ ],
-  "count": 12
+  "count": 42
+}
+```
+
+> **Note:** `count` is the **total** number of reports for the user (not the page size). Use it with `limit`/`offset` to build pagination controls (e.g., "Page 1 of 3").
+
+---
+
+## TypeScript Types to Add
+
+Add these to `ghosthands.types.ts`:
+
+```typescript
+export interface GHSubmittedField {
+  prompt_text: string;
+  value: string;
+  question_type: 'text' | 'textarea' | 'email' | 'tel' | 'url' | 'number' | 'date' | 'file' | 'select' | 'radio' | 'checkbox' | 'unknown';
+  source: 'dom' | 'llm' | 'magnitude' | 'manual';
+  answer_mode?: 'profile_backed' | 'best_effort_guess' | 'default_decline' | 'system_attachment' | null;
+  confidence: number;
+  required: boolean;
+  section_label?: string | null;
+  state: 'verified' | 'filled' | 'failed' | 'uncertain' | 'planned' | 'attempted';
+}
+
+export interface GHApplicationReport {
+  id: string;
+  job_id: string;
+  user_id: string;
+  valet_task_id: string | null;
+  job_url: string;
+  company_name: string | null;
+  job_title: string | null;
+  platform: string | null;
+  resume_ref: string | null;
+  fields_submitted: GHSubmittedField[];
+  total_fields: number;
+  fields_filled: number;
+  fields_failed: number;
+  fields_unresolved: number;
+  status: 'completed' | 'failed' | 'awaiting_review';
+  submitted: boolean;
+  result_summary: string | null;
+  llm_cost_cents: number | null;
+  action_count: number | null;
+  total_tokens: number | null;
+  screenshot_urls: string[];
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GHGetReportResponse {
+  report: GHApplicationReport;
+}
+
+export interface GHListReportsResponse {
+  reports: GHApplicationReport[];
+  count: number; // total count for the user (not page size)
 }
 ```
 
 ---
 
-## `fields_submitted` Schema
+## Client Methods to Add
+
+Add these to `ghosthands.client.ts`, following the same pattern as `getJobStatus()`:
+
+```typescript
+async getApplicationReport(jobId: string): Promise<GHGetReportResponse | null> {
+  // GET /api/v1/gh/valet/reports/:jobId
+  // Returns null on 404 (report not found)
+}
+
+async listUserReports(userId: string, limit = 50, offset = 0): Promise<GHListReportsResponse> {
+  // GET /api/v1/gh/valet/reports/user/:userId?limit=X&offset=Y
+}
+```
+
+---
+
+## `fields_submitted` Schema Reference
 
 Each element in the `fields_submitted` JSONB array:
 
@@ -130,7 +228,7 @@ Each element in the `fields_submitted` JSONB array:
 ## Resume Reference Resolution
 
 The `resume_ref` field contains the storage path (e.g., `resumes/resume-abc.pdf`). This is NOT the user-facing filename. VALET should:
-1. Parse the resume ID from the path
+1. Parse the resume ID from the path (the UUID portion after `resumes/`)
 2. Look up the resume record in the VALET `resumes` table to get the display name
 3. Show the display name in the UI (e.g., "Software Engineer Resume.pdf")
 
@@ -138,26 +236,29 @@ The `resume_ref` field contains the storage path (e.g., `resumes/resume-abc.pdf`
 
 ## VALET Implementation Checklist
 
-### Backend
-- [ ] Add a service/helper to call `GET /valet/reports/:jobId` from GH API
-- [ ] Add a service/helper to call `GET /valet/reports/user/:userId` from GH API
-- [ ] Cache report data if needed (reports are immutable after creation)
-- [ ] Resolve `resume_ref` to user-facing resume name
+### Backend (`apps/api/src/modules/ghosthands/`)
+- [ ] Add `GHSubmittedField`, `GHApplicationReport`, `GHGetReportResponse`, `GHListReportsResponse` types to `ghosthands.types.ts`
+- [ ] Add `getApplicationReport(jobId)` method to `ghosthands.client.ts`
+- [ ] Add `listUserReports(userId, limit?, offset?)` method to `ghosthands.client.ts`
+- [ ] Resolve `resume_ref` to user-facing resume name via VALET's `resumes` table
+- [ ] Cache report data if needed (reports are immutable once status is `completed` — but may update from `awaiting_review` → `completed`)
 
 ### Frontend (Application Tracker UI)
-- [ ] Create Application Tracker page/component (similar to Tsenta screenshot)
-- [ ] Display list of applications with: company, status, date, field count
-- [ ] Detail view: show all `fields_submitted` as a table with columns:
+- [ ] Create Application Tracker page/component
+- [ ] **List view:** display applications with: company, status, date, field count, pagination
+- [ ] **Detail view:** show all `fields_submitted` as a table with columns:
   - Field Name (`prompt_text`)
   - Value Submitted (`value`)
   - Type (`question_type`)
   - Confidence badge (green >=0.9, yellow 0.7-0.9, red <0.7)
   - Required indicator
+  - State badge
 - [ ] Show summary stats: total fields, filled, failed, unresolved
 - [ ] Show cost info: `llm_cost_cents`, `action_count`
 - [ ] Show screenshots (clickable thumbnails)
 - [ ] Show resume used (resolved display name)
 - [ ] Filter/sort applications by: date, company, platform, status
+- [ ] Pagination controls using `count` (total) with `limit`/`offset`
 
 ### Visual Indicators
 - **State badges:**
@@ -183,3 +284,4 @@ The `resume_ref` field contains the storage path (e.g., `resumes/resume-abc.pdf`
 - When a job transitions from `awaiting_review` → `completed`, the report is updated via upsert (same `job_id`).
 - Sensitive fields (passwords, SSNs, tokens) are automatically redacted to `[REDACTED]`. User PII like phone numbers and addresses are NOT redacted since the user needs to verify them.
 - The `company_name` is best-effort extracted from the URL (works well for Workday, Greenhouse, Lever — may be null for unknown ATS platforms).
+- Both endpoints are rate-limited (same middleware as other valet routes).

--- a/docs/VALET-INTEGRATION-CONTRACT.md
+++ b/docs/VALET-INTEGRATION-CONTRACT.md
@@ -555,6 +555,80 @@ Returns all registered workers with status, heartbeat, and job counts.
 }
 ```
 
+### 4.11 Get Application Report — `GET /valet/reports/:jobId`
+
+Returns the structured application report for a single job, containing every field the worker filled.
+
+**Response (200):**
+
+```json
+{
+  "report": {
+    "id": "uuid",
+    "job_id": "uuid",
+    "user_id": "uuid",
+    "valet_task_id": "vt-789",
+    "job_url": "https://mycompany.wd5.myworkdayjobs.com/en-US/External/job/apply",
+    "company_name": "mycompany",
+    "job_title": null,
+    "platform": "workday",
+    "resume_ref": "resumes/resume-abc.pdf",
+    "fields_submitted": [
+      {
+        "prompt_text": "First Name",
+        "value": "John",
+        "question_type": "text",
+        "source": "dom",
+        "answer_mode": "profile_backed",
+        "confidence": 0.95,
+        "required": true,
+        "section_label": "Personal Information",
+        "state": "verified"
+      }
+    ],
+    "total_fields": 15,
+    "fields_filled": 13,
+    "fields_failed": 1,
+    "fields_unresolved": 1,
+    "status": "completed",
+    "submitted": true,
+    "result_summary": "Application submitted successfully",
+    "llm_cost_cents": 5,
+    "action_count": 10,
+    "total_tokens": 1500,
+    "screenshot_urls": ["https://s3.amazonaws.com/..."],
+    "started_at": "2026-03-08T10:00:00Z",
+    "completed_at": "2026-03-08T10:02:30Z",
+    "created_at": "2026-03-08T10:02:30Z",
+    "updated_at": "2026-03-08T10:02:30Z"
+  }
+}
+```
+
+**Response (404):** Report not found for the given `jobId`.
+
+### 4.12 List Application Reports — `GET /valet/reports/user/:userId`
+
+Returns paginated application reports for a user, ordered by most recent first.
+
+**Query params:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | number | 50 | Max results per page (1–100) |
+| `offset` | number | 0 | Pagination offset |
+
+**Response (200):**
+
+```json
+{
+  "reports": [ /* array of report objects, same shape as 4.11 */ ],
+  "count": 12
+}
+```
+
+> **Note:** Reports are written best-effort during job finalization. A small percentage of jobs may not have reports if the DB write fails. The `resume_ref` field contains a storage path — VALET should resolve this to a display name via its own `resumes` table. Sensitive fields (passwords, SSNs) are automatically redacted to `[REDACTED]`.
+
 ---
 
 ## 5. Callback System (Push Notifications)
@@ -956,6 +1030,7 @@ All GhostHands tables use the `gh_` prefix (shared Supabase with VALET).
 | `gh_action_manuals` | Saved step-by-step playbooks per platform+task |
 | `gh_user_usage` | Monthly cost tracking per user |
 | `gh_user_credentials` | Encrypted platform credentials |
+| `gh_application_reports` | Structured per-job application reports (fields filled, cost, screenshots) |
 
 ### 8.2 Key Columns on `gh_automation_jobs`
 
@@ -984,6 +1059,7 @@ All GhostHands tables use the `gh_` prefix (shared Supabase with VALET).
 | 011 | `011_execution_mode_tracking.sql` | Execution mode columns |
 | 012 | `012_gh_job_events_realtime.sql` | Enable Realtime on gh_job_events |
 | 025 | `025_add_cost_columns.sql` | Cost-tracking columns on gh_automation_jobs |
+| 026 | `026_gh_application_reports.sql` | Application reports table with RLS |
 
 ---
 

--- a/docs/VALET-INTEGRATION-CONTRACT.md
+++ b/docs/VALET-INTEGRATION-CONTRACT.md
@@ -623,7 +623,7 @@ Returns paginated application reports for a user, ordered by most recent first.
 ```json
 {
   "reports": [ /* array of report objects, same shape as 4.11 */ ],
-  "count": 12
+  "count": 12  // total reports for user (not page count)
 }
 ```
 

--- a/docs/VALET-INTEGRATION-CONTRACT.md
+++ b/docs/VALET-INTEGRATION-CONTRACT.md
@@ -555,79 +555,11 @@ Returns all registered workers with status, heartbeat, and job counts.
 }
 ```
 
-### 4.11 Get Application Report — `GET /valet/reports/:jobId`
+### 4.11 Application Reports (Direct DB Access)
 
-Returns the structured application report for a single job, containing every field the worker filled.
+GhostHands writes structured application reports to `gh_application_reports` during job finalization. VALET reads this table directly via Supabase (shared DB) — there are no GH API endpoints for report reads. See Section 8 for the table schema.
 
-**Response (200):**
-
-```json
-{
-  "report": {
-    "id": "uuid",
-    "job_id": "uuid",
-    "user_id": "uuid",
-    "valet_task_id": "vt-789",
-    "job_url": "https://mycompany.wd5.myworkdayjobs.com/en-US/External/job/apply",
-    "company_name": "mycompany",
-    "job_title": null,
-    "platform": "workday",
-    "resume_ref": "resumes/resume-abc.pdf",
-    "fields_submitted": [
-      {
-        "prompt_text": "First Name",
-        "value": "John",
-        "question_type": "text",
-        "source": "dom",
-        "answer_mode": "profile_backed",
-        "confidence": 0.95,
-        "required": true,
-        "section_label": "Personal Information",
-        "state": "verified"
-      }
-    ],
-    "total_fields": 15,
-    "fields_filled": 13,
-    "fields_failed": 1,
-    "fields_unresolved": 1,
-    "status": "completed",
-    "submitted": true,
-    "result_summary": "Application submitted successfully",
-    "llm_cost_cents": 5,
-    "action_count": 10,
-    "total_tokens": 1500,
-    "screenshot_urls": ["https://s3.amazonaws.com/..."],
-    "started_at": "2026-03-08T10:00:00Z",
-    "completed_at": "2026-03-08T10:02:30Z",
-    "created_at": "2026-03-08T10:02:30Z",
-    "updated_at": "2026-03-08T10:02:30Z"
-  }
-}
-```
-
-**Response (404):** Report not found for the given `jobId`.
-
-### 4.12 List Application Reports — `GET /valet/reports/user/:userId`
-
-Returns paginated application reports for a user, ordered by most recent first.
-
-**Query params:**
-
-| Param | Type | Default | Description |
-|-------|------|---------|-------------|
-| `limit` | number | 50 | Max results per page (1–100) |
-| `offset` | number | 0 | Pagination offset |
-
-**Response (200):**
-
-```json
-{
-  "reports": [ /* array of report objects, same shape as 4.11 */ ],
-  "count": 12  // total reports for user (not page count)
-}
-```
-
-> **Note:** Reports are written best-effort during job finalization. A small percentage of jobs may not have reports if the DB write fails. The `resume_ref` field contains a storage path — VALET should resolve this to a display name via its own `resumes` table. Sensitive fields (passwords, SSNs) are automatically redacted to `[REDACTED]`.
+> **Note:** Reports are written best-effort. A small percentage of jobs may not have reports if the DB write fails. The `resume_ref` field contains a storage path — VALET should resolve this to a display name via its own `resumes` table. Sensitive fields (passwords, SSNs) are automatically redacted to `[REDACTED]`.
 
 ---
 

--- a/packages/ghosthands/__tests__/unit/workers/reportBuilder.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/reportBuilder.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from 'vitest';
+import {
+  extractFieldsFromSession,
+  extractCompanyFromUrl,
+  buildApplicationReport,
+} from '../../../src/workers/reportBuilder';
+import type { PageContextSession } from '../../../src/context/types';
+import type { AutomationJob, TaskResult } from '../../../src/workers/taskHandlers/types';
+import type { CostSnapshot } from '../../../src/workers/costControl';
+
+// ---------------------------------------------------------------------------
+// Helpers to build test fixtures
+// ---------------------------------------------------------------------------
+
+function makeQuestion(overrides: Record<string, any> = {}) {
+  return {
+    questionKey: 'q-1',
+    orderIndex: 0,
+    promptText: 'First Name',
+    normalizedPrompt: 'first name',
+    questionType: 'text' as const,
+    required: true,
+    groupingConfidence: 1,
+    resolutionConfidence: 0.95,
+    riskLevel: 'none' as const,
+    state: 'verified' as const,
+    source: 'dom' as const,
+    selectors: [],
+    options: [],
+    currentValue: 'John',
+    selectedOptions: [],
+    lastAnswer: 'John',
+    answerMode: 'profile_backed' as const,
+    attemptCount: 1,
+    verificationCount: 1,
+    warnings: [],
+    fieldIds: [],
+    lastUpdatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makePage(questions: any[] = [], overrides: Record<string, any> = {}) {
+  return {
+    pageId: 'page-1',
+    sequence: 0,
+    pageStepKey: 'step-1',
+    entryFingerprint: 'fp-1',
+    latestFingerprint: 'fp-1',
+    url: 'https://example.com/apply',
+    pageType: 'application_form',
+    pageTitle: 'Apply',
+    status: 'completed' as const,
+    enteredAt: new Date().toISOString(),
+    lastSeenAt: new Date().toISOString(),
+    visitCount: 1,
+    questions,
+    actionables: [],
+    history: [],
+    coverage: {
+      requiredTotal: questions.length,
+      requiredResolved: questions.length,
+      requiredUnresolved: 0,
+      optionalRisky: 0,
+      lowConfidenceResolved: 0,
+      ambiguousGrouped: 0,
+    },
+    mergeStats: { questionMergeCount: 0, resumedCount: 0, duplicateQuestionSuppressions: 0 },
+    ...overrides,
+  };
+}
+
+function makeSession(pages: any[] = []): PageContextSession {
+  return {
+    jobId: 'job-123',
+    mastraRunId: 'run-1',
+    startedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    status: 'completed',
+    pages,
+    reportDraft: {
+      pagesVisited: pages.length,
+      requiredUnresolved: [],
+      riskyOptionalAnswers: [],
+      lowConfidenceAnswers: [],
+      ambiguousQuestionGroups: [],
+      bestEffortGuesses: [],
+      partialPages: [],
+      flushStatus: 'flushed',
+    },
+    version: 1,
+  };
+}
+
+function makeJob(overrides: Record<string, any> = {}): AutomationJob {
+  return {
+    id: 'job-123',
+    job_type: 'smart_apply',
+    target_url: 'https://mycompany.wd5.myworkdayjobs.com/en-US/External/job/apply',
+    task_description: 'Apply to job',
+    input_data: { user_data: { first_name: 'John' } },
+    user_id: 'user-456',
+    timeout_seconds: 300,
+    max_retries: 2,
+    retry_count: 0,
+    metadata: {},
+    priority: 0,
+    tags: [],
+    valet_task_id: 'vt-789',
+    resume_ref: 'resumes/resume-abc.pdf',
+    ...overrides,
+  } as AutomationJob;
+}
+
+function makeCostSnapshot(): CostSnapshot {
+  return {
+    totalCost: 0.05,
+    inputTokens: 1000,
+    outputTokens: 500,
+    actionCount: 10,
+    imageCost: 0.01,
+    reasoningCost: 0.02,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('extractFieldsFromSession', () => {
+  test('extracts verified/filled fields', () => {
+    const session = makeSession([
+      makePage([
+        makeQuestion({ state: 'verified', promptText: 'First Name', lastAnswer: 'John' }),
+        makeQuestion({ state: 'filled', promptText: 'Email', lastAnswer: 'john@example.com', questionKey: 'q-2' }),
+      ]),
+    ]);
+
+    const fields = extractFieldsFromSession(session);
+    expect(fields).toHaveLength(2);
+    expect(fields[0].prompt_text).toBe('First Name');
+    expect(fields[0].value).toBe('John');
+    expect(fields[0].state).toBe('verified');
+    expect(fields[1].prompt_text).toBe('Email');
+    expect(fields[1].value).toBe('john@example.com');
+  });
+
+  test('includes failed fields with empty value', () => {
+    const session = makeSession([
+      makePage([
+        makeQuestion({ state: 'failed', promptText: 'Cover Letter', lastAnswer: undefined, currentValue: undefined, questionKey: 'q-3' }),
+      ]),
+    ]);
+
+    const fields = extractFieldsFromSession(session);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].state).toBe('failed');
+    expect(fields[0].value).toBe('');
+  });
+
+  test('skips retired questions', () => {
+    const session = makeSession([
+      makePage([
+        makeQuestion({
+          state: 'skipped',
+          warnings: ['retired_missing_from_dom'],
+          questionKey: 'q-retired',
+        }),
+        makeQuestion({ state: 'verified', promptText: 'Name', questionKey: 'q-keep' }),
+      ]),
+    ]);
+
+    const fields = extractFieldsFromSession(session);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].prompt_text).toBe('Name');
+  });
+
+  test('skips empty questions with no answer', () => {
+    const session = makeSession([
+      makePage([
+        makeQuestion({ state: 'empty', lastAnswer: undefined, currentValue: undefined, questionKey: 'q-empty' }),
+      ]),
+    ]);
+
+    const fields = extractFieldsFromSession(session);
+    expect(fields).toHaveLength(0);
+  });
+
+  test('redacts sensitive fields (password, SSN)', () => {
+    const session = makeSession([
+      makePage([
+        makeQuestion({ promptText: 'Password', lastAnswer: 'secret123', questionKey: 'q-pwd' }),
+        makeQuestion({ promptText: 'Social Security Number', lastAnswer: '123-45-6789', questionKey: 'q-ssn' }),
+        makeQuestion({ promptText: 'Phone', lastAnswer: '555-1234', questionKey: 'q-phone' }),
+      ]),
+    ]);
+
+    const fields = extractFieldsFromSession(session);
+    expect(fields).toHaveLength(3);
+    expect(fields[0].value).toBe('[REDACTED]');
+    expect(fields[1].value).toBe('[REDACTED]');
+    expect(fields[2].value).toBe('555-1234'); // Phone NOT redacted
+  });
+
+  test('handles empty session', () => {
+    const session = makeSession([]);
+    const fields = extractFieldsFromSession(session);
+    expect(fields).toHaveLength(0);
+  });
+
+  test('extracts across multiple pages', () => {
+    const session = makeSession([
+      makePage([makeQuestion({ promptText: 'Page 1 Field', questionKey: 'q-p1' })]),
+      makePage([makeQuestion({ promptText: 'Page 2 Field', questionKey: 'q-p2' })], { pageId: 'page-2', sequence: 1 }),
+    ]);
+
+    const fields = extractFieldsFromSession(session);
+    expect(fields).toHaveLength(2);
+    expect(fields[0].prompt_text).toBe('Page 1 Field');
+    expect(fields[1].prompt_text).toBe('Page 2 Field');
+  });
+});
+
+describe('extractCompanyFromUrl', () => {
+  test('extracts from Workday URL', () => {
+    expect(extractCompanyFromUrl('https://mycompany.wd5.myworkdayjobs.com/en-US/External')).toBe('mycompany');
+  });
+
+  test('extracts from Greenhouse URL', () => {
+    expect(extractCompanyFromUrl('https://boards.greenhouse.io/acmecorp/jobs/123')).toBe('acmecorp');
+  });
+
+  test('extracts from Lever URL', () => {
+    expect(extractCompanyFromUrl('https://jobs.lever.co/coolstartup/abc-123')).toBe('coolstartup');
+  });
+
+  test('extracts from generic careers URL', () => {
+    const result = extractCompanyFromUrl('https://careers.google.com/apply/123');
+    expect(result).toBe('google');
+  });
+
+  test('returns null for invalid URL', () => {
+    expect(extractCompanyFromUrl('not-a-url')).toBeNull();
+  });
+});
+
+describe('buildApplicationReport', () => {
+  test('builds complete report from session + job', () => {
+    const session = makeSession([
+      makePage([
+        makeQuestion({ state: 'verified', promptText: 'First Name', lastAnswer: 'John' }),
+        makeQuestion({ state: 'failed', promptText: 'Cover Letter', lastAnswer: '', questionKey: 'q-fail' }),
+      ]),
+    ]);
+    const job = makeJob();
+    const cost = makeCostSnapshot();
+    const taskResult: TaskResult = { success: true, data: { submitted: true, platform: 'workday' } };
+
+    const report = buildApplicationReport(job, session, cost, taskResult, ['https://s3/screenshot.png'], 'completed');
+
+    expect(report.job_id).toBe('job-123');
+    expect(report.user_id).toBe('user-456');
+    expect(report.valet_task_id).toBe('vt-789');
+    expect(report.company_name).toBe('mycompany');
+    expect(report.platform).toBe('workday');
+    expect(report.resume_ref).toBe('resumes/resume-abc.pdf');
+    expect(report.fields_submitted).toHaveLength(2);
+    expect(report.total_fields).toBe(2);
+    expect(report.fields_filled).toBe(1);
+    expect(report.fields_failed).toBe(1);
+    expect(report.submitted).toBe(true);
+    expect(report.status).toBe('completed');
+    expect(report.llm_cost_cents).toBe(5);
+    expect(report.action_count).toBe(10);
+    expect(report.screenshot_urls).toEqual(['https://s3/screenshot.png']);
+  });
+
+  test('handles null session gracefully', () => {
+    const job = makeJob();
+    const cost = makeCostSnapshot();
+    const taskResult: TaskResult = { success: false, error: 'timeout' };
+
+    const report = buildApplicationReport(job, null, cost, taskResult, [], 'failed');
+
+    expect(report.fields_submitted).toEqual([]);
+    expect(report.total_fields).toBe(0);
+    expect(report.fields_filled).toBe(0);
+    expect(report.status).toBe('failed');
+    expect(report.submitted).toBe(false);
+  });
+
+  test('extracts resume_ref from object', () => {
+    const job = makeJob({ resume_ref: { path: 'resumes/my-resume.pdf', url: 'https://storage/...' } });
+    const report = buildApplicationReport(job, null, makeCostSnapshot(), { success: true }, [], 'completed');
+    expect(report.resume_ref).toBe('resumes/my-resume.pdf');
+  });
+});

--- a/packages/ghosthands/__tests__/unit/workers/reportBuilder.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/reportBuilder.test.ts
@@ -107,7 +107,7 @@ function makeJob(overrides: Record<string, any> = {}): AutomationJob {
     priority: 0,
     tags: [],
     valet_task_id: 'vt-789',
-    resume_ref: 'resumes/resume-abc.pdf',
+    resume_ref: { storage_path: 'resumes/resume-abc.pdf' },
     ...overrides,
   } as AutomationJob;
 }

--- a/packages/ghosthands/__tests__/unit/workers/reportBuilder.test.ts
+++ b/packages/ghosthands/__tests__/unit/workers/reportBuilder.test.ts
@@ -290,7 +290,7 @@ describe('buildApplicationReport', () => {
   });
 
   test('extracts resume_ref from object', () => {
-    const job = makeJob({ resume_ref: { path: 'resumes/my-resume.pdf', url: 'https://storage/...' } });
+    const job = makeJob({ resume_ref: { storage_path: 'resumes/my-resume.pdf', download_url: 'https://storage/...' } });
     const report = buildApplicationReport(job, null, makeCostSnapshot(), { success: true }, [], 'completed');
     expect(report.resume_ref).toBe('resumes/my-resume.pdf');
   });

--- a/packages/ghosthands/src/api/routes/valet.ts
+++ b/packages/ghosthands/src/api/routes/valet.ts
@@ -534,44 +534,7 @@ export function createValetRoutes(pool: pg.Pool) {
     });
   });
 
-  // ─── GET /valet/reports/:jobId — Application report for a job ──
 
-  valet.get('/reports/:jobId', rateLimitMiddleware(), async (c) => {
-    const jobId = c.req.param('jobId');
-
-    const { rows } = await pool.query(`
-      SELECT * FROM gh_application_reports WHERE job_id = $1::UUID
-    `, [jobId]);
-
-    if (rows.length === 0) {
-      return c.json({ error: 'not_found', message: 'Report not found' }, 404);
-    }
-
-    return c.json({ report: rows[0] });
-  });
-
-  // ─── GET /valet/reports/user/:userId — List reports for a user ──
-
-  valet.get('/reports/user/:userId', rateLimitMiddleware(), async (c) => {
-    const userId = c.req.param('userId');
-    const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '50', 10) || 50, 1), 100);
-    const offset = Math.max(parseInt(c.req.query('offset') || '0', 10) || 0, 0);
-
-    const [{ rows }, countResult] = await Promise.all([
-      pool.query(`
-        SELECT * FROM gh_application_reports
-        WHERE user_id = $1::UUID
-        ORDER BY created_at DESC
-        LIMIT $2 OFFSET $3
-      `, [userId, limit, offset]),
-      pool.query(`
-        SELECT COUNT(*)::int AS total FROM gh_application_reports
-        WHERE user_id = $1::UUID
-      `, [userId]),
-    ]);
-
-    return c.json({ reports: rows, count: countResult.rows[0].total });
-  });
 
   return valet;
 }

--- a/packages/ghosthands/src/api/routes/valet.ts
+++ b/packages/ghosthands/src/api/routes/valet.ts
@@ -554,8 +554,8 @@ export function createValetRoutes(pool: pg.Pool) {
 
   valet.get('/reports/user/:userId', async (c) => {
     const userId = c.req.param('userId');
-    const limit = Math.min(parseInt(c.req.query('limit') || '50', 10), 100);
-    const offset = Math.max(parseInt(c.req.query('offset') || '0', 10), 0);
+    const limit = Math.min(parseInt(c.req.query('limit') || '50', 10) || 50, 100);
+    const offset = Math.max(parseInt(c.req.query('offset') || '0', 10) || 0, 0);
 
     const { rows } = await pool.query(`
       SELECT * FROM gh_application_reports

--- a/packages/ghosthands/src/api/routes/valet.ts
+++ b/packages/ghosthands/src/api/routes/valet.ts
@@ -536,7 +536,7 @@ export function createValetRoutes(pool: pg.Pool) {
 
   // ─── GET /valet/reports/:jobId — Application report for a job ──
 
-  valet.get('/reports/:jobId', async (c) => {
+  valet.get('/reports/:jobId', rateLimitMiddleware(), async (c) => {
     const jobId = c.req.param('jobId');
 
     const { rows } = await pool.query(`
@@ -552,9 +552,9 @@ export function createValetRoutes(pool: pg.Pool) {
 
   // ─── GET /valet/reports/user/:userId — List reports for a user ──
 
-  valet.get('/reports/user/:userId', async (c) => {
+  valet.get('/reports/user/:userId', rateLimitMiddleware(), async (c) => {
     const userId = c.req.param('userId');
-    const limit = Math.min(parseInt(c.req.query('limit') || '50', 10) || 50, 100);
+    const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '50', 10) || 50, 1), 100);
     const offset = Math.max(parseInt(c.req.query('offset') || '0', 10) || 0, 0);
 
     const { rows } = await pool.query(`

--- a/packages/ghosthands/src/api/routes/valet.ts
+++ b/packages/ghosthands/src/api/routes/valet.ts
@@ -557,14 +557,20 @@ export function createValetRoutes(pool: pg.Pool) {
     const limit = Math.min(Math.max(parseInt(c.req.query('limit') || '50', 10) || 50, 1), 100);
     const offset = Math.max(parseInt(c.req.query('offset') || '0', 10) || 0, 0);
 
-    const { rows } = await pool.query(`
-      SELECT * FROM gh_application_reports
-      WHERE user_id = $1::UUID
-      ORDER BY created_at DESC
-      LIMIT $2 OFFSET $3
-    `, [userId, limit, offset]);
+    const [{ rows }, countResult] = await Promise.all([
+      pool.query(`
+        SELECT * FROM gh_application_reports
+        WHERE user_id = $1::UUID
+        ORDER BY created_at DESC
+        LIMIT $2 OFFSET $3
+      `, [userId, limit, offset]),
+      pool.query(`
+        SELECT COUNT(*)::int AS total FROM gh_application_reports
+        WHERE user_id = $1::UUID
+      `, [userId]),
+    ]);
 
-    return c.json({ reports: rows, count: rows.length });
+    return c.json({ reports: rows, count: countResult.rows[0].total });
   });
 
   return valet;

--- a/packages/ghosthands/src/api/routes/valet.ts
+++ b/packages/ghosthands/src/api/routes/valet.ts
@@ -534,5 +534,38 @@ export function createValetRoutes(pool: pg.Pool) {
     });
   });
 
+  // ─── GET /valet/reports/:jobId — Application report for a job ──
+
+  valet.get('/reports/:jobId', async (c) => {
+    const jobId = c.req.param('jobId');
+
+    const { rows } = await pool.query(`
+      SELECT * FROM gh_application_reports WHERE job_id = $1::UUID
+    `, [jobId]);
+
+    if (rows.length === 0) {
+      return c.json({ error: 'not_found', message: 'Report not found' }, 404);
+    }
+
+    return c.json({ report: rows[0] });
+  });
+
+  // ─── GET /valet/reports/user/:userId — List reports for a user ──
+
+  valet.get('/reports/user/:userId', async (c) => {
+    const userId = c.req.param('userId');
+    const limit = Math.min(parseInt(c.req.query('limit') || '50', 10), 100);
+    const offset = Math.max(parseInt(c.req.query('offset') || '0', 10), 0);
+
+    const { rows } = await pool.query(`
+      SELECT * FROM gh_application_reports
+      WHERE user_id = $1::UUID
+      ORDER BY created_at DESC
+      LIMIT $2 OFFSET $3
+    `, [userId, limit, offset]);
+
+    return c.json({ reports: rows, count: rows.length });
+  });
+
   return valet;
 }

--- a/packages/ghosthands/src/context/NoopPageContextService.ts
+++ b/packages/ghosthands/src/context/NoopPageContextService.ts
@@ -2,6 +2,7 @@ import type {
   AnswerDecision,
   ContextReport,
   PageAuditResult,
+  PageContextSession,
   PageEntryInput,
   PageFinalizeInput,
   QuestionOutcome,
@@ -42,5 +43,8 @@ export class NoopPageContextService implements PageContextService {
   }
   async flushToSupabase(): Promise<ContextReport> {
     return this.getContextReport('pending');
+  }
+  async getSession(): Promise<PageContextSession | null> {
+    return null;
   }
 }

--- a/packages/ghosthands/src/context/PageContextService.ts
+++ b/packages/ghosthands/src/context/PageContextService.ts
@@ -111,6 +111,8 @@ export interface PageContextService {
   markFlushPending(error: string): Promise<void>;
   getContextReport(flushStatus?: ContextReport['flushStatus']): Promise<ContextReport>;
   flushToSupabase(): Promise<ContextReport>;
+  /** Return the raw session snapshot (for report extraction). */
+  getSession(): Promise<PageContextSession | null>;
 }
 
 export class LivePageContextService implements PageContextService {
@@ -280,6 +282,10 @@ export class LivePageContextService implements PageContextService {
     await this.persistCurrent(baseVersion);
     await this.store.retain(this.session, this.keepDebugRetention);
     return report;
+  }
+
+  async getSession(): Promise<PageContextSession | null> {
+    return this.session;
   }
 
   private async ensureSession(): Promise<PageContextSession> {

--- a/packages/ghosthands/src/db/migrations/026_gh_application_reports.sql
+++ b/packages/ghosthands/src/db/migrations/026_gh_application_reports.sql
@@ -71,10 +71,16 @@ CREATE INDEX IF NOT EXISTS idx_gh_app_reports_valet_task
 -- RLS
 ALTER TABLE gh_application_reports ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Service role full access on gh_application_reports"
-  ON gh_application_reports FOR ALL
-  TO service_role
-  USING (true) WITH CHECK (true);
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE policyname = 'Service role full access on gh_application_reports'
+  ) THEN
+    CREATE POLICY "Service role full access on gh_application_reports"
+      ON gh_application_reports FOR ALL
+      TO service_role
+      USING (true) WITH CHECK (true);
+  END IF;
+END $$;
 
 -- DOWN (rollback — commented)
 -- DROP TABLE IF EXISTS gh_application_reports;

--- a/packages/ghosthands/src/db/migrations/026_gh_application_reports.sql
+++ b/packages/ghosthands/src/db/migrations/026_gh_application_reports.sql
@@ -1,0 +1,80 @@
+-- Migration 026: Application reports — structured record of what the worker submitted
+--
+-- Stores a per-job flat report of every field filled during an application,
+-- queryable by VALET UI for the Application Tracker feature.
+-- Data is populated during job finalization from PageContextSession.
+--
+-- Key points:
+-- - One row per job (unique on job_id)
+-- - fields_submitted is a JSONB array of {prompt_text, value, question_type, source, ...}
+-- - Best-effort write — report failures never block job finalization
+-- - RLS: service role full access (workers write), authenticated users read own
+
+-- UP
+
+CREATE TABLE IF NOT EXISTS gh_application_reports (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id          UUID NOT NULL REFERENCES gh_automation_jobs(id) ON DELETE CASCADE,
+  user_id         UUID NOT NULL,
+  valet_task_id   TEXT,
+
+  -- Application metadata
+  job_url         TEXT NOT NULL,
+  company_name    TEXT,
+  job_title       TEXT,
+  platform        TEXT,
+
+  -- Resume used
+  resume_ref      TEXT,
+
+  -- What the worker submitted (core payload)
+  -- Array of { prompt_text, value, question_type, source, answer_mode, confidence, required, section_label, state }
+  fields_submitted JSONB NOT NULL DEFAULT '[]'::jsonb,
+
+  -- Summary counts
+  total_fields       INTEGER NOT NULL DEFAULT 0,
+  fields_filled      INTEGER NOT NULL DEFAULT 0,
+  fields_failed      INTEGER NOT NULL DEFAULT 0,
+  fields_unresolved  INTEGER NOT NULL DEFAULT 0,
+
+  -- Submission outcome
+  status          TEXT NOT NULL DEFAULT 'completed',
+  submitted       BOOLEAN NOT NULL DEFAULT false,
+  result_summary  TEXT,
+
+  -- Cost
+  llm_cost_cents  INTEGER,
+  action_count    INTEGER,
+  total_tokens    INTEGER,
+
+  -- Screenshots
+  screenshot_urls JSONB DEFAULT '[]'::jsonb,
+
+  -- Timestamps
+  started_at      TIMESTAMPTZ,
+  completed_at    TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gh_app_reports_job
+  ON gh_application_reports(job_id);
+
+CREATE INDEX IF NOT EXISTS idx_gh_app_reports_user
+  ON gh_application_reports(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gh_app_reports_valet_task
+  ON gh_application_reports(valet_task_id)
+  WHERE valet_task_id IS NOT NULL;
+
+-- RLS
+ALTER TABLE gh_application_reports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on gh_application_reports"
+  ON gh_application_reports FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+-- DOWN (rollback — commented)
+-- DROP TABLE IF EXISTS gh_application_reports;

--- a/packages/ghosthands/src/events/JobEventTypes.ts
+++ b/packages/ghosthands/src/events/JobEventTypes.ts
@@ -67,6 +67,9 @@ export const JOB_EVENT_TYPES = {
 
   // Form submission (used by recovery to detect partial applications)
   FORM_SUBMITTED: 'form_submitted',
+
+  // Application report
+  REPORT_GENERATED: 'report_generated',
 } as const;
 
 export type JobEventType = (typeof JOB_EVENT_TYPES)[keyof typeof JOB_EVENT_TYPES];

--- a/packages/ghosthands/src/workers/finalization.ts
+++ b/packages/ghosthands/src/workers/finalization.ts
@@ -32,6 +32,7 @@ import type { SessionManager } from '../sessions/SessionManager.js';
 import { getLogger } from '../monitoring/logger.js';
 import type { PageContextService } from '../context/PageContextService.js';
 import type { ContextReport } from '../context/types.js';
+import { buildApplicationReport, writeApplicationReport } from './reportBuilder.js';
 
 // ---------------------------------------------------------------------------
 // Shared input interface
@@ -253,6 +254,42 @@ function fireCallbackBestEffort(
     });
 }
 
+/**
+ * Build and persist an application report. Best-effort — never throws.
+ */
+async function writeReportBestEffort(
+  supabase: SupabaseClient,
+  job: AutomationJob,
+  pageContext: PageContextService | undefined,
+  costSnapshot: CostSnapshot,
+  taskResult: TaskResult,
+  screenshotUrls: string[],
+  status: 'completed' | 'failed' | 'awaiting_review',
+  logEvent: CommonFinalizationInput['logEvent'],
+): Promise<void> {
+  try {
+    const session = pageContext ? await pageContext.getSession() : null;
+    const reportData = buildApplicationReport(
+      job,
+      session,
+      costSnapshot,
+      taskResult,
+      screenshotUrls,
+      status,
+    );
+    await writeApplicationReport(supabase, reportData);
+    await logEvent('report_generated', {
+      fields_filled: reportData.fields_filled,
+      total_fields: reportData.total_fields,
+    }).catch(() => {});
+  } catch (err) {
+    logger.warn('Application report generation failed', {
+      jobId: job.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -380,6 +417,9 @@ export async function finalizeHandlerResult(
     // Best-effort cost recording
     recordCostBestEffort(supabase, job.user_id, job.id, finalCost);
 
+    // Best-effort application report
+    await writeReportBestEffort(supabase, job, pageContext, finalCost, taskResult, screenshotUrls, 'awaiting_review', logEvent);
+
     logger.info('Job awaiting user review', {
       jobId: job.id,
       actionCount: finalCost.actionCount,
@@ -446,6 +486,9 @@ export async function finalizeHandlerResult(
 
     recordCostBestEffort(supabase, job.user_id, job.id, finalCost);
 
+    // Best-effort application report
+    await writeReportBestEffort(supabase, job, pageContext, finalCost, taskResult, screenshotUrls, 'failed', logEvent);
+
     fireCallbackBestEffort(
       job,
       workerId,
@@ -500,6 +543,9 @@ export async function finalizeHandlerResult(
 
   // Best-effort cost recording
   recordCostBestEffort(supabase, job.user_id, job.id, finalCost);
+
+  // Best-effort application report
+  await writeReportBestEffort(supabase, job, pageContext, finalCost, taskResult, screenshotUrls, 'completed', logEvent);
 
   // Fire VALET callback
   fireCallbackBestEffort(

--- a/packages/ghosthands/src/workers/finalization.ts
+++ b/packages/ghosthands/src/workers/finalization.ts
@@ -277,11 +277,13 @@ async function writeReportBestEffort(
       screenshotUrls,
       status,
     );
-    await writeApplicationReport(supabase, reportData);
-    await logEvent('report_generated', {
-      fields_filled: reportData.fields_filled,
-      total_fields: reportData.total_fields,
-    }).catch(() => {});
+    const written = await writeApplicationReport(supabase, reportData);
+    if (written) {
+      await logEvent('report_generated', {
+        fields_filled: reportData.fields_filled,
+        total_fields: reportData.total_fields,
+      }).catch(() => {});
+    }
   } catch (err) {
     logger.warn('Application report generation failed', {
       jobId: job.id,

--- a/packages/ghosthands/src/workers/reportBuilder.ts
+++ b/packages/ghosthands/src/workers/reportBuilder.ts
@@ -1,0 +1,279 @@
+/**
+ * ReportBuilder — Builds structured application reports from PageContextSession data.
+ *
+ * Extracts every field the worker filled (or failed to fill) into a flat array
+ * suitable for storage in gh_application_reports.fields_submitted JSONB column.
+ * VALET UI can query this directly to show the user what was submitted.
+ *
+ * Design:
+ * - Primary data source: PageContextSession (all pages, all questions)
+ * - Sensitive fields (passwords, SSNs) are redacted
+ * - Non-sensitive user data (phone, address) is kept visible
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PageContextSession, QuestionRecord } from '../context/types.js';
+import type { AutomationJob, TaskResult } from './taskHandlers/types.js';
+import type { CostSnapshot } from './costControl.js';
+import { getLogger } from '../monitoring/logger.js';
+
+const logger = getLogger({ service: 'report-builder' });
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SubmittedField {
+  prompt_text: string;
+  value: string;
+  question_type: string;
+  source: string;
+  answer_mode?: string;
+  confidence: number;
+  required: boolean;
+  section_label?: string;
+  state: string;
+}
+
+export interface ApplicationReportData {
+  job_id: string;
+  user_id: string;
+  valet_task_id?: string | null;
+  job_url: string;
+  company_name?: string | null;
+  job_title?: string | null;
+  platform?: string | null;
+  resume_ref?: string | null;
+  fields_submitted: SubmittedField[];
+  total_fields: number;
+  fields_filled: number;
+  fields_failed: number;
+  fields_unresolved: number;
+  status: string;
+  submitted: boolean;
+  result_summary?: string | null;
+  llm_cost_cents?: number | null;
+  action_count?: number | null;
+  total_tokens?: number | null;
+  screenshot_urls?: string[];
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Sensitive field redaction (passwords, SSNs — NOT phone/address)
+// ---------------------------------------------------------------------------
+
+const SENSITIVE_FIELD_RE = /password|passwd|pwd|secret|token|otp|ssn|credit.?card|cvv|pin|social.?security/i;
+
+function redactValue(promptText: string, value: string): string {
+  if (SENSITIVE_FIELD_RE.test(promptText)) {
+    return '[REDACTED]';
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Field extraction from PageContextSession
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all filled fields from a PageContextSession into a flat array.
+ * Includes verified, filled, AND failed fields so users see the full picture.
+ */
+export function extractFieldsFromSession(session: PageContextSession): SubmittedField[] {
+  const fields: SubmittedField[] = [];
+
+  for (const page of session.pages) {
+    for (const question of page.questions) {
+      // Skip retired/removed questions
+      if (question.state === 'skipped' && question.warnings.includes('retired_missing_from_dom')) {
+        continue;
+      }
+
+      // Skip questions that were never attempted (empty + no answer planned)
+      if (question.state === 'empty' && !question.lastAnswer) {
+        continue;
+      }
+
+      const rawValue = question.lastAnswer || question.currentValue || '';
+
+      fields.push({
+        prompt_text: question.promptText,
+        value: redactValue(question.promptText, rawValue),
+        question_type: question.questionType,
+        source: question.source,
+        answer_mode: question.answerMode,
+        confidence: question.resolutionConfidence,
+        required: question.required,
+        section_label: question.sectionLabel,
+        state: question.state,
+      });
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Count field states from an extracted fields array.
+ */
+function countFields(fields: SubmittedField[]): {
+  total: number;
+  filled: number;
+  failed: number;
+  unresolved: number;
+} {
+  let filled = 0;
+  let failed = 0;
+  let unresolved = 0;
+
+  for (const f of fields) {
+    if (f.state === 'verified' || f.state === 'filled') {
+      filled++;
+    } else if (f.state === 'failed') {
+      failed++;
+    } else {
+      unresolved++;
+    }
+  }
+
+  return { total: fields.length, filled, failed, unresolved };
+}
+
+// ---------------------------------------------------------------------------
+// Company/title extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt to extract a company name from a URL.
+ * e.g. "https://careers.google.com/apply" → "google"
+ *      "https://mycompany.wd5.myworkdayjobs.com/..." → "mycompany"
+ */
+export function extractCompanyFromUrl(url: string): string | null {
+  try {
+    const hostname = new URL(url).hostname;
+    // Workday pattern: <company>.wd<N>.myworkdayjobs.com
+    const workdayMatch = hostname.match(/^([^.]+)\.wd\d+\.myworkdayjobs\.com$/i);
+    if (workdayMatch) return workdayMatch[1];
+
+    // Greenhouse pattern: boards.greenhouse.io/<company>
+    if (hostname === 'boards.greenhouse.io') {
+      const path = new URL(url).pathname.split('/').filter(Boolean);
+      return path[0] || null;
+    }
+
+    // Lever pattern: jobs.lever.co/<company>
+    if (hostname === 'jobs.lever.co') {
+      const path = new URL(url).pathname.split('/').filter(Boolean);
+      return path[0] || null;
+    }
+
+    // Generic: use first subdomain or second-level domain
+    const parts = hostname.split('.');
+    if (parts.length >= 2) {
+      // Skip common prefixes
+      const skip = ['www', 'careers', 'jobs', 'apply', 'boards'];
+      for (const part of parts) {
+        if (!skip.includes(part) && part.length > 2) {
+          return part;
+        }
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main report builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an ApplicationReportData from a PageContextSession + job metadata.
+ * Called during finalization after page context is flushed.
+ */
+export function buildApplicationReport(
+  job: AutomationJob,
+  session: PageContextSession | null,
+  costSnapshot: CostSnapshot,
+  taskResult: TaskResult,
+  screenshotUrls: string[],
+  status: 'completed' | 'failed' | 'awaiting_review',
+): ApplicationReportData {
+  const fields = session ? extractFieldsFromSession(session) : [];
+  const counts = countFields(fields);
+  const inputData = job.input_data || {};
+
+  const resultSummary =
+    taskResult.data?.success_message ||
+    taskResult.data?.summary ||
+    taskResult.data?.message ||
+    null;
+
+  return {
+    job_id: job.id,
+    user_id: job.user_id,
+    valet_task_id: job.valet_task_id || null,
+    job_url: job.target_url,
+    company_name: extractCompanyFromUrl(job.target_url),
+    job_title: inputData.job_title || null,
+    platform: inputData.platform || taskResult.data?.platform || null,
+    resume_ref: typeof job.resume_ref === 'string'
+      ? job.resume_ref
+      : (job.resume_ref as Record<string, any>)?.path || (job.resume_ref as Record<string, any>)?.url || null,
+    fields_submitted: fields,
+    total_fields: counts.total,
+    fields_filled: counts.filled,
+    fields_failed: counts.failed,
+    fields_unresolved: counts.unresolved,
+    status,
+    submitted: taskResult.data?.submitted === true,
+    result_summary: resultSummary,
+    llm_cost_cents: Math.round(costSnapshot.totalCost * 100),
+    action_count: costSnapshot.actionCount,
+    total_tokens: costSnapshot.inputTokens + costSnapshot.outputTokens,
+    screenshot_urls: screenshotUrls,
+    started_at: job.metadata?.started_at || null,
+    completed_at: status === 'completed' || status === 'failed' ? new Date().toISOString() : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Database writer (best-effort)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write an application report to gh_application_reports. Best-effort — never
+ * throws. Failures are logged and swallowed so they never block job finalization.
+ */
+export async function writeApplicationReport(
+  supabase: SupabaseClient,
+  reportData: ApplicationReportData,
+): Promise<void> {
+  try {
+    const { error } = await supabase
+      .from('gh_application_reports')
+      .upsert([reportData], { onConflict: 'job_id' });
+
+    if (error) {
+      logger.warn('Failed to write application report', {
+        jobId: reportData.job_id,
+        error: error.message,
+      });
+    } else {
+      logger.info('Application report written', {
+        jobId: reportData.job_id,
+        fieldsFilled: reportData.fields_filled,
+        totalFields: reportData.total_fields,
+      });
+    }
+  } catch (err) {
+    logger.warn('Application report write threw', {
+      jobId: reportData.job_id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/packages/ghosthands/src/workers/reportBuilder.ts
+++ b/packages/ghosthands/src/workers/reportBuilder.ts
@@ -255,7 +255,7 @@ export function buildApplicationReport(
 export async function writeApplicationReport(
   supabase: SupabaseClient,
   reportData: ApplicationReportData,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const { error } = await supabase
       .from('gh_application_reports')
@@ -266,17 +266,20 @@ export async function writeApplicationReport(
         jobId: reportData.job_id,
         error: error.message,
       });
-    } else {
-      logger.info('Application report written', {
-        jobId: reportData.job_id,
-        fieldsFilled: reportData.fields_filled,
-        totalFields: reportData.total_fields,
-      });
+      return false;
     }
+
+    logger.info('Application report written', {
+      jobId: reportData.job_id,
+      fieldsFilled: reportData.fields_filled,
+      totalFields: reportData.total_fields,
+    });
+    return true;
   } catch (err) {
     logger.warn('Application report write threw', {
       jobId: reportData.job_id,
       error: err instanceof Error ? err.message : String(err),
     });
+    return false;
   }
 }

--- a/packages/ghosthands/src/workers/reportBuilder.ts
+++ b/packages/ghosthands/src/workers/reportBuilder.ts
@@ -213,7 +213,7 @@ export function buildApplicationReport(
     taskResult.data?.success_message ||
     taskResult.data?.summary ||
     taskResult.data?.message ||
-    null;
+    (taskResult.data?.submitted ? 'Application submitted successfully' : null);
 
   return {
     job_id: job.id,

--- a/packages/ghosthands/src/workers/reportBuilder.ts
+++ b/packages/ghosthands/src/workers/reportBuilder.ts
@@ -173,10 +173,11 @@ export function extractCompanyFromUrl(url: string): string | null {
     // Generic: use first subdomain or second-level domain
     const parts = hostname.split('.');
     if (parts.length >= 2) {
-      // Skip common prefixes
+      // Skip common prefixes and TLDs
       const skip = ['www', 'careers', 'jobs', 'apply', 'boards'];
+      const tlds = ['com', 'org', 'net', 'io', 'co', 'gov', 'edu', 'info', 'biz'];
       for (const part of parts) {
-        if (!skip.includes(part) && part.length > 2) {
+        if (!skip.includes(part) && !tlds.includes(part) && part.length > 2) {
           return part;
         }
       }

--- a/packages/ghosthands/src/workers/reportBuilder.ts
+++ b/packages/ghosthands/src/workers/reportBuilder.ts
@@ -97,7 +97,7 @@ export function extractFieldsFromSession(session: PageContextSession): Submitted
         continue;
       }
 
-      const rawValue = question.lastAnswer || question.currentValue || '';
+      const rawValue = question.lastAnswer ?? question.currentValue ?? '';
 
       fields.push({
         prompt_text: question.promptText,

--- a/packages/ghosthands/src/workers/reportBuilder.ts
+++ b/packages/ghosthands/src/workers/reportBuilder.ts
@@ -58,6 +58,7 @@ export interface ApplicationReportData {
   screenshot_urls?: string[];
   started_at?: string | null;
   completed_at?: string | null;
+  updated_at?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +224,7 @@ export function buildApplicationReport(
     platform: inputData.platform || taskResult.data?.platform || null,
     resume_ref: typeof job.resume_ref === 'string'
       ? job.resume_ref
-      : (job.resume_ref as Record<string, any>)?.path || (job.resume_ref as Record<string, any>)?.url || null,
+      : (job.resume_ref as Record<string, any>)?.storage_path || (job.resume_ref as Record<string, any>)?.download_url || (job.resume_ref as Record<string, any>)?.s3_key || null,
     fields_submitted: fields,
     total_fields: counts.total,
     fields_filled: counts.filled,
@@ -238,6 +239,7 @@ export function buildApplicationReport(
     screenshot_urls: screenshotUrls,
     started_at: job.metadata?.started_at || null,
     completed_at: status === 'completed' || status === 'failed' ? new Date().toISOString() : null,
+    updated_at: new Date().toISOString(),
   };
 }
 


### PR DESCRIPTION
## Summary
- New `gh_application_reports` table (migration 026) stores structured report of every field filled during job applications
- `reportBuilder.ts` extracts fields from PageContextSession with sensitive field redaction (passwords/SSNs)
- Best-effort report writes integrated into all 3 finalization paths (completed, failed, awaiting_review)
- Two new VALET API endpoints: `GET /valet/reports/:jobId` and `GET /valet/reports/user/:userId`
- VALET handoff doc at `docs/VALET-APPLICATION-REPORTS-TODO.md` for frontend integration

## Test plan
- [x] 15 unit tests for reportBuilder (field extraction, redaction, company URL parsing, full report build)
- [ ] Integration test: verify report is written after job completion
- [ ] Verify VALET endpoints return correct data shape
- [ ] Confirm RLS policies work with service_role access

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
