### PR TITLE
fix: wire pageContext into all execution paths for live context snapshots

### DIFF
--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -760,14 +760,23 @@ export class JobExecutor {
         this.logJobEvent(job.id, eventType, metadata);
 
       // 9.1. Wire page context for real-time context snapshots (non-Mastra path)
+      // Best-effort: Redis unavailability should not block job execution
       if (this.redis) {
-        pageContext = new LivePageContextService(
-          job.id,
-          new RedisPageContextStore(this.redis, job.id),
-          new SupabasePageContextFlusher(this.supabase),
-        );
-        await pageContext.initializeRun(`run-${job.id}`);
-        progress.setPageContext(pageContext);
+        try {
+          pageContext = new LivePageContextService(
+            job.id,
+            new RedisPageContextStore(this.redis, job.id),
+            new SupabasePageContextFlusher(this.supabase),
+          );
+          await pageContext.initializeRun(`run-${job.id}-${this._executionAttemptId ?? '0'}`);
+          progress.setPageContext(pageContext);
+        } catch (err) {
+          getLogger().warn('Page context init failed (non-fatal, continuing without context snapshots)', {
+            jobId: job.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          pageContext = null;
+        }
       }
 
       // 9a. Wire up event tracking with cost control + progress
@@ -998,6 +1007,8 @@ export class JobExecutor {
           contextAlreadyFlushed = true;
         } catch (err) {
           getLogger().warn('Page context flush failed (non-fatal)', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
+          // Mark as pending so a future backfill can pick it up
+          await pageContext.markFlushPending(err instanceof Error ? err.message : String(err)).catch(() => {});
         }
       }
 

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -755,6 +755,18 @@ export class JobExecutor {
       const logEventFn = (eventType: string, metadata: Record<string, any>) =>
         this.logJobEvent(job.id, eventType, metadata);
 
+      // 9.1. Wire page context for real-time context snapshots (non-Mastra path)
+      let pageContext: PageContextService | null = null;
+      if (this.redis) {
+        pageContext = new LivePageContextService(
+          job.id,
+          new RedisPageContextStore(this.redis, job.id),
+          new SupabasePageContextFlusher(this.supabase),
+        );
+        await pageContext.initializeRun(`run-${job.id}`);
+        progress.setPageContext(pageContext);
+      }
+
       // 9a. Wire up event tracking with cost control + progress
       const thoughtThrottle = new ThoughtThrottle(2000);
       const targetDomain = new URL(job.target_url).hostname;
@@ -806,6 +818,7 @@ export class JobExecutor {
           resumeFilePath,
           emailVerification: emailVerification || undefined,
           logEvent: logEventFn,
+          ...(pageContext && { pageContext }),
         };
 
         try {
@@ -973,6 +986,15 @@ export class JobExecutor {
         getLogger().info('Saved fresh session cookies', { userId: job.user_id });
       } catch (err) {
         getLogger().warn('Session save failed (non-fatal)', { error: err instanceof Error ? err.message : String(err) });
+      }
+
+      // 12.7. Flush page context report if wired
+      if (pageContext) {
+        try {
+          await pageContext.getContextReport('completed');
+        } catch (err) {
+          getLogger().warn('Page context flush failed (non-fatal)', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
+        }
       }
 
       // 13. Handle awaiting_review vs completed

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -329,6 +329,7 @@ export class JobExecutor {
 
     // Declared outside try so error handler can flush on failure
     let pageContext: PageContextService | null = null;
+    let contextAlreadyFlushed = false;
 
     try {
       // 0a. Stamp execution_attempt_id to prevent duplicate execution (EC3)
@@ -994,6 +995,7 @@ export class JobExecutor {
       if (pageContext) {
         try {
           await pageContext.flushToSupabase();
+          contextAlreadyFlushed = true;
         } catch (err) {
           getLogger().warn('Page context flush failed (non-fatal)', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
         }
@@ -1279,7 +1281,7 @@ export class JobExecutor {
         actionCount: snapshot.actionCount,
         totalTokens: snapshot.inputTokens + snapshot.outputTokens,
         totalCost: snapshot.totalCost,
-        ...(pageContext && { pageContext }),
+        ...(pageContext && { pageContext, contextFlushed: contextAlreadyFlushed }),
       });
 
       // Always record cost on failure (even zero cost for consistent accounting)

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -327,6 +327,9 @@ export class JobExecutor {
       ...(this.redis && { redis: this.redis }),
     });
 
+    // Declared outside try so error handler can flush on failure
+    let pageContext: PageContextService | null = null;
+
     try {
       // 0a. Stamp execution_attempt_id to prevent duplicate execution (EC3)
       if (this.pgPool) {
@@ -756,7 +759,6 @@ export class JobExecutor {
         this.logJobEvent(job.id, eventType, metadata);
 
       // 9.1. Wire page context for real-time context snapshots (non-Mastra path)
-      let pageContext: PageContextService | null = null;
       if (this.redis) {
         pageContext = new LivePageContextService(
           job.id,

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -991,7 +991,7 @@ export class JobExecutor {
       // 12.7. Flush page context report if wired
       if (pageContext) {
         try {
-          await pageContext.getContextReport('completed');
+          await pageContext.getContextReport('flushed');
         } catch (err) {
           getLogger().warn('Page context flush failed (non-fatal)', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
         }

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -991,7 +991,7 @@ export class JobExecutor {
       // 12.7. Flush page context report if wired
       if (pageContext) {
         try {
-          await pageContext.getContextReport('flushed');
+          await pageContext.flushToSupabase();
         } catch (err) {
           getLogger().warn('Page context flush failed (non-fatal)', { jobId: job.id, error: err instanceof Error ? err.message : String(err) });
         }
@@ -1277,6 +1277,7 @@ export class JobExecutor {
         actionCount: snapshot.actionCount,
         totalTokens: snapshot.inputTokens + snapshot.outputTokens,
         totalCost: snapshot.totalCost,
+        ...(pageContext && { pageContext }),
       });
 
       // Always record cost on failure (even zero cost for consistent accounting)

--- a/packages/ghosthands/src/workers/progressTracker.ts
+++ b/packages/ghosthands/src/workers/progressTracker.ts
@@ -238,7 +238,9 @@ export class ProgressTracker {
     const now = Date.now();
     const elapsedMs = now - this.startedAt;
     const session = this.pageContextReader?.getSessionSync() ?? null;
-    const contextReportSnapshot = session ? computeSnapshotCounts(session) : undefined;
+    const rawSnapshot = session ? computeSnapshotCounts(session) : undefined;
+    // Only include snapshot when pages have been visited — avoids misleading all-zero cards
+    const contextReportSnapshot = rawSnapshot && rawSnapshot.pagesVisited > 0 ? rawSnapshot : undefined;
 
     return {
       step: this.currentStep,


### PR DESCRIPTION
## Summary
- Wire `LivePageContextService` into non-Mastra handler execution paths (smart_apply, agent_apply, magnitude) so `context_report_snapshot` is emitted during all jobs with Redis
- Guard `getSnapshot()` to only include snapshot when `pagesVisited > 0` — prevents misleading all-zero context report cards
- Flush page context report on successful job completion

## Root Cause
`pageContext` was only created and wired in `executeMastraWorkflow()`. Non-Mastra handlers never received it, so `context_report_snapshot` was always null in progress events.

## Changes
- `JobExecutor.ts`: Create `LivePageContextService` before non-Mastra handler execution when Redis available, pass into TaskContext, flush on completion
- `progressTracker.ts`: Add `pagesVisited > 0` guard to avoid zeroed snapshots

## Test plan
- [x] 1080 unit tests pass (0 fail)
- [x] TypeScript compiles
- [ ] Staging smoke test: run a non-Mastra job and verify context_report_snapshot appears in SSE events

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
