### PR TITLE
fix: add missing bringToFront() to StagehandPageCompat

### DIFF
--- a/packages/ghosthands/src/__tests__/unit/stagehandCompat.test.ts
+++ b/packages/ghosthands/src/__tests__/unit/stagehandCompat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { StagehandPageCompat as AdapterStagehandPageCompat } from '../../adapters/stagehandCompat.js';
+import { StagehandPageCompat as EngineStagehandPageCompat } from '../../engine/v3/StagehandCompat.js';
+
+describe('StagehandPageCompat', () => {
+  test('delegates bringToFront to the underlying Stagehand page in both compat layers', async () => {
+    let callCount = 0;
+    const rawPage = {
+      bringToFront: async () => {
+        callCount += 1;
+      },
+    };
+    const stagehand = {} as any;
+
+    await new AdapterStagehandPageCompat(rawPage, stagehand).bringToFront();
+    await new EngineStagehandPageCompat(rawPage, stagehand).bringToFront();
+
+    expect(callCount).toBe(2);
+  });
+});

--- a/packages/ghosthands/src/adapters/stagehandCompat.ts
+++ b/packages/ghosthands/src/adapters/stagehandCompat.ts
@@ -605,6 +605,10 @@ export class StagehandPageCompat {
     return this._stagehandPage.close();
   }
 
+  async bringToFront(): Promise<void> {
+    return this._stagehandPage.bringToFront();
+  }
+
   async title(): Promise<string> {
     return this._stagehandPage.title();
   }

--- a/packages/ghosthands/src/engine/v3/StagehandCompat.ts
+++ b/packages/ghosthands/src/engine/v3/StagehandCompat.ts
@@ -605,6 +605,10 @@ export class StagehandPageCompat {
     return this._stagehandPage.close();
   }
 
+  async bringToFront(): Promise<void> {
+    return this._stagehandPage.bringToFront();
+  }
+
   async title(): Promise<string> {
     return this._stagehandPage.title();
   }


### PR DESCRIPTION
## Summary
- Adds `bringToFront()` method to `StagehandPageCompat` class, delegating to the underlying Stagehand page
- Called by `smartApplyHandler.ts` and `emailVerification/service.ts` to bring the automation page to front after navigation
- Prevents about:blank tabs from persisting in the browser during job execution

## Test plan
- [ ] Run a job that triggers email verification — browser should bring the correct tab to front
- [ ] Run a smart apply job — no lingering about:blank tabs after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
