### PR TITLE
fix(engine): Magnitude fallback for 0-field pages + stuck detection fix

### DIFF
--- a/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
@@ -3339,7 +3339,25 @@ export async function fillFormOnPage(
   console.log(`[formFiller] Found ${visibleFields.length} visible fields (${llmFields.length} non-file).`);
 
   if (visibleFields.length === 0) {
-    console.log('[formFiller] No visible fields found — skipping fill.');
+    // DOM scanner found no fields. Sites like SmartRecruiters use custom React
+    // components that don't render as standard <input>/<select>/<textarea>.
+    // Fall through to Magnitude visual fill so the AI agent can interact with
+    // the form visually instead of returning empty.
+    console.log('[formFiller] No visible DOM fields found — attempting Magnitude visual fill.');
+    try {
+      const today = new Date().toLocaleDateString('en-CA');
+      const visualPrompt =
+        `You are filling out a job application for this person. Today's date is ${today}.\n` +
+        `${profileText.trim()}\n\n` +
+        `Look at the current page and fill in ALL visible form fields using the applicant's profile. ` +
+        `Fill text fields, select dropdowns, upload the resume if there is a file upload, and check any required checkboxes. ` +
+        `Work through the form from top to bottom. Do NOT click any Submit or Next buttons.`;
+      await adapter.act(visualPrompt, { timeoutMs: 60_000 });
+      result.magnitudeFilled = 1; // approximate — visual fill handles multiple fields
+      console.log('[formFiller] Magnitude visual fill completed (0 DOM fields, used visual agent).');
+    } catch (err: any) {
+      console.warn(`[formFiller] Magnitude visual fill failed: ${err?.message ?? err}`);
+    }
     return result;
   }
 

--- a/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
@@ -3103,12 +3103,20 @@ ${dataPrompt}`;
       const h = document.querySelector('h1, h2, h3');
       const heading = (h?.textContent || '').trim().substring(0, 60);
 
-      // Count visible form fields as a content signature
+      // Count visible form fields AND how many are filled vs empty.
+      // Including filled count ensures the fingerprint changes after formFiller
+      // fills fields — preventing false "stuck" detection on SPAs where the
+      // URL and heading stay constant across fill cycles.
       const fields = document.querySelectorAll('input:not([type="hidden"]), select, textarea');
       let visibleFieldCount = 0;
+      let filledFieldCount = 0;
       for (const f of fields) {
         const rect = f.getBoundingClientRect();
-        if (rect.width > 0 && rect.height > 0) visibleFieldCount++;
+        if (rect.width > 0 && rect.height > 0) {
+          visibleFieldCount++;
+          const el = f as HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement;
+          if (el.value && el.value.trim()) filledFieldCount++;
+        }
       }
 
       // Active sidebar/step indicator (common in multi-step forms)
@@ -3127,7 +3135,7 @@ ${dataPrompt}`;
         }
       }
 
-      return `${heading}|fields:${visibleFieldCount}|active:${activeText}`;
+      return `${heading}|fields:${visibleFieldCount}|filled:${filledFieldCount}|active:${activeText}`;
     });
   }
 


### PR DESCRIPTION
## Summary
- **SmartRecruiters fix**: When DOM field scanner finds 0 visible fields (SmartRecruiters uses custom React components), formFiller now falls through to Magnitude visual fill instead of returning empty. The AI agent fills the form visually.
- **Greenhouse fix**: `getPageFingerprint()` now includes filled field count in the signature. After formFiller fills fields, the fingerprint changes — preventing false "stuck" detection and unnecessary Magnitude escalation on SPAs.

## Test plan
- [ ] Queue a SmartRecruiters one-click apply URL — should now fill fields via Magnitude visual agent instead of looping with "0 visible fields"
- [ ] Queue a Greenhouse URL — should NOT escalate to Magnitude on second pass after fields were filled
- [ ] Verify Workday and Amazon flows still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
