### PR TITLE
fix(engine): prevent Magnitude cascade on zero-field sites

### DIFF
--- a/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/formFiller.ts
@@ -3341,8 +3341,19 @@ export async function fillFormOnPage(
   if (visibleFields.length === 0) {
     // DOM scanner found no fields. Sites like SmartRecruiters use custom React
     // components that don't render as standard <input>/<select>/<textarea>.
-    // Fall through to Magnitude visual fill so the AI agent can interact with
-    // the form visually instead of returning empty.
+    // Try Magnitude visual fill — but only if the adapter isn't already poisoned
+    // from a previous timed-out act() call.
+
+    // Check if adapter mutex is poisoned (previous act() still running).
+    // If so, skip visual fill entirely — it will just fail with "adapter busy".
+    if (adapter.waitForActSettle) {
+      const settled = await adapter.waitForActSettle(1_000);
+      if (!settled) {
+        console.log('[formFiller] No visible DOM fields + adapter busy from previous act() — skipping Magnitude visual fill.');
+        return result;
+      }
+    }
+
     console.log('[formFiller] No visible DOM fields found — attempting Magnitude visual fill.');
     try {
       const today = new Date().toLocaleDateString('en-CA');
@@ -3352,11 +3363,17 @@ export async function fillFormOnPage(
         `Look at the current page and fill in ALL visible form fields using the applicant's profile. ` +
         `Fill text fields, select dropdowns, upload the resume if there is a file upload, and check any required checkboxes. ` +
         `Work through the form from top to bottom. Do NOT click any Submit or Next buttons.`;
-      await adapter.act(visualPrompt, { timeoutMs: 60_000 });
-      result.magnitudeFilled = 1; // approximate — visual fill handles multiple fields
+      await adapter.act(visualPrompt, { timeoutMs: 30_000 });
+      result.magnitudeFilled = 1;
       console.log('[formFiller] Magnitude visual fill completed (0 DOM fields, used visual agent).');
     } catch (err: any) {
-      console.warn(`[formFiller] Magnitude visual fill failed: ${err?.message ?? err}`);
+      const msg = err?.message ?? String(err);
+      console.warn(`[formFiller] Magnitude visual fill failed: ${msg}`);
+      // After timeout, wait briefly for settle to prevent cascading busy errors
+      // on subsequent pages.
+      if (msg.includes('timed out') && adapter.waitForActSettle) {
+        await adapter.waitForActSettle(5_000);
+      }
     }
     return result;
   }

--- a/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
+++ b/packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts
@@ -40,6 +40,10 @@ export class SmartApplyHandler implements TaskHandler {
   loginAttempted = false;
   /** True after clicking Apply — prevents SPA re-detection as job_listing */
   private applyClicked = false;
+  /** Tracks last fill result so the main loop can detect consecutive zero-field pages */
+  private _lastFillTotalFields = -1;
+  private _lastFillDomFilled = -1;
+  private _lastFillMagnitudeFilled = -1;
 
   validate(inputData: Record<string, any>): ValidationResult {
     const errors: string[] = [];
@@ -152,8 +156,10 @@ export class SmartApplyHandler implements TaskHandler {
     let pagesProcessed = 0;
     let lastPageSignature = '';
     let samePageCount = 0;
+    let consecutiveZeroFieldPages = 0;
     const ESCALATE_AFTER = 3;  // escalate to MagnitudeHand after this many stuck iterations
     const MAX_SAME_PAGE = 6;   // bail after this many total stuck iterations (3 DOM + 3 Magnitude)
+    const MAX_ZERO_FIELD_PAGES = 3; // bail if N consecutive pages have 0 fields (site incompatible)
 
     try {
       // Main detect-and-act loop
@@ -430,6 +436,31 @@ export class SmartApplyHandler implements TaskHandler {
                   message: 'Application filled. Waiting for user to review and submit.',
                 },
               };
+            }
+            // Track consecutive zero-field pages: if the site consistently has
+            // 0 detectable form fields, it's incompatible with our field extraction.
+            // Bail early instead of looping through Magnitude timeouts.
+            if (this._lastFillTotalFields === 0 && this._lastFillDomFilled === 0 && this._lastFillMagnitudeFilled === 0) {
+              consecutiveZeroFieldPages++;
+              if (consecutiveZeroFieldPages >= MAX_ZERO_FIELD_PAGES) {
+                console.warn(`[SmartApply] ${consecutiveZeroFieldPages} consecutive pages with 0 detectable fields — site uses non-standard form components. Stopping.`);
+                await pageContext?.finalizeActivePage({ status: 'blocked' });
+                await pageContext?.markAwaitingReview();
+                await progress.setStep(ProgressStep.AWAITING_USER_REVIEW);
+                return {
+                  success: true,
+                  keepBrowserOpen: true,
+                  awaitingUserReview: true,
+                  data: {
+                    platform: config.platformId,
+                    pages_processed: pagesProcessed,
+                    final_page: 'incompatible',
+                    message: 'Site uses non-standard form components that cannot be automated. Browser open for manual takeover.',
+                  },
+                };
+              }
+            } else {
+              consecutiveZeroFieldPages = 0;
             }
             // 'navigated' and 'complete' both continue the main loop
             break;
@@ -2019,6 +2050,10 @@ IMPORTANT: Do NOT select, clear, or retype any already-filled fields.`,
           : undefined,
       });
       console.log(`[SmartApply] formFiller: ${fillResult.domFilled} DOM + ${fillResult.magnitudeFilled} Magnitude filled (${fillResult.llmCalls} LLM calls)`);
+      // Expose fill counts for the main loop's zero-field detection
+      this._lastFillTotalFields = fillResult.totalFields;
+      this._lastFillDomFilled = fillResult.domFilled;
+      this._lastFillMagnitudeFilled = fillResult.magnitudeFilled;
 
       // Record formFiller LLM token usage in cost tracker.
       // formFiller uses claude-haiku-4-5 directly — compute cost from known pricing.


### PR DESCRIPTION
## Summary
- **SmartRecruiters fix**: Sites with custom React components (0 DOM fields) caused Magnitude to timeout, poison the adapter mutex, then every subsequent page failed with "adapter busy" — 5+ min wasted loops
- **formFiller**: Check adapter busy state before visual fill, reduce timeout 60s→30s, await settle after timeout
- **smartApplyHandler**: Bail after 3 consecutive zero-field pages (site incompatible)

## Before → After
- SmartRecruiters: 7 pages × 60s timeout = ~5+ min of nothing → bails in ~35s with "manual takeover" message
- Adapter busy cascade eliminated — poisoned mutex detected and skipped

## Test plan
- [ ] Queue SmartRecruiters URL → should bail after 3 pages with "incompatible" message
- [ ] Queue Greenhouse URL → should fill normally (17 fields detected, no change in behavior)
- [ ] Queue Ashby URL → should fill normally (14 fields detected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
