### PR TITLE
fix(engine): stabilize post-auth observation and eliminate page races

### DIFF
--- a/docs/MASTRA-DECISION-ENGINE-ARCHITECTURE.md
+++ b/docs/MASTRA-DECISION-ENGINE-ARCHITECTURE.md
@@ -1,0 +1,1098 @@
+# Mastra Decision Engine — Architecture Document
+
+**Author:** Backend Architect
+**Date:** 2026-03-11
+**Branch:** `feat/octo-mastra-decision-engine`
+**Status:** Design Phase
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Current Architecture Baseline](#2-current-architecture-baseline)
+3. [New Mastra Workflow Design](#3-new-mastra-workflow-design)
+4. [LLM Decision Call Design](#4-llm-decision-call-design)
+5. [Execution Cascade Design](#5-execution-cascade-design)
+6. [Termination Conditions](#6-termination-conditions)
+7. [Desktop Entry Point Changes](#7-desktop-entry-point-changes)
+8. [Worker Entry Point Changes](#8-worker-entry-point-changes)
+9. [Workflow State Schema Changes](#9-workflow-state-schema-changes)
+10. [File Changes Inventory](#10-file-changes-inventory)
+11. [Migration Path](#11-migration-path)
+12. [Risk Assessment](#12-risk-assessment)
+13. [Appendix: Sequence Diagrams](#13-appendix-sequence-diagrams)
+
+---
+
+## 1. Executive Summary
+
+Today the Mastra workflow has two steps: `check_blockers_checkpoint` and `execute_handler`. The `execute_handler` step delegates entirely to `SmartApplyHandler.execute()`, which runs a monolithic ~700-line page loop that interleaves observation, form filling, navigation, stuck detection, and platform-specific heuristics all inside a single function.
+
+This design replaces `execute_handler` with a **page decision loop** (`page_decision_loop`) that runs inside a single Mastra step but is internally structured as a repeating observe-decide-act cycle. An LLM decision call examines the current page state and chooses from a constrained action schema. Actions are executed via a three-tier cascade: DOM -> Stagehand -> Magnitude. The loop terminates on confirmation, review, error, stuck detection, or budget exhaustion.
+
+**Key design decisions:**
+
+- The loop runs inside a **single Mastra step** (not one step per page iteration). Rationale: Mastra suspend/resume serializes state to Postgres, which adds ~200ms latency per transition and prevents holding non-serializable objects (Playwright Page, adapter). The loop needs sub-second iteration.
+- HITL suspend points are added **within the loop** at blocker detection points, using the same `suspend()` mechanism already proven in `check_blockers_checkpoint`.
+- SmartApplyHandler remains as a **fallback** behind a feature flag during rollout.
+- The v3 engine's `DOMHand`, `StagehandHand`, and `MagnitudeHand` are reused directly as the execution cascade.
+
+---
+
+## 2. Current Architecture Baseline
+
+### 2.1 Mastra Workflow (2 steps)
+
+```
+buildApplyWorkflow(RuntimeContext)
+  |
+  v
+[Step 1] check_blockers_checkpoint
+  - BlockerDetector.detectWithAdapter()
+  - HITL suspend/resume (Mastra suspend())
+  - Reads resolution_data from DB
+  - Injects resolution via adapter.act()
+  |
+  v
+[Step 2] execute_handler
+  - Builds TaskContext from RuntimeContext
+  - Calls rt.handler.execute(ctx) -- usually SmartApplyHandler
+  - Maps TaskResult to WorkflowState
+  - Sets final status: completed | failed | awaiting_review
+```
+
+### 2.2 SmartApplyHandler Page Loop (what we are replacing)
+
+```
+while (pagesProcessed < 15):
+  1. waitForPageLoad()
+  2. dismissCookieBanner()
+  3. detectPage() -- platform-specific page type detection
+  4. getPageFingerprint() -- stuck detection
+  5. Branch on page_type:
+     - job_listing: click Apply button
+     - login/account_creation: handle credentials
+     - questions/basic_info/...: fillFormOnPage()
+     - review: stop for manual review
+     - confirmation: mark success
+  6. After fill: detect next-page navigation
+  7. Update pageContext snapshots
+```
+
+### 2.3 Existing v3 Engine (partially built, not wired)
+
+The `packages/ghosthands/src/engine/v3/` directory contains:
+
+- `LayerHand` (abstract base): observe(), process(), execute(), review(), throwError()
+- `DOMHand` ($0/action): PageScanner + FieldMatcher + DOMActionExecutor
+- `StagehandHand` ($0.0005/action): Stagehand a11y observe + DOM fill
+- `MagnitudeHand` ($0.005/action): Screenshot + vision LLM agent
+- `SectionOrchestrator`: Per-page loop that groups fields into sections, fills cheapest-first with escalation
+
+These layers are mature but not yet wired into any production path.
+
+### 2.4 Entry Points
+
+| Entry Point | Path | Current Behavior |
+|---|---|---|
+| **Hosted Worker** | `jobExecutor.ts` -> `executeMastraWorkflow()` | Builds RuntimeContext, creates Mastra workflow, handles suspend/resume/finalization |
+| **Desktop (direct)** | `packages/engine/src/runApplication.ts` | Launches magnitude-core directly, cookbook-first, LLM fallback. No Mastra. |
+| **Desktop (brokered)** | `packages/engine/src/desktop.ts` -> `broker.submitSmartApply()` | Submits to hosted API, does not run locally |
+
+---
+
+## 3. New Mastra Workflow Design
+
+### 3.1 Workflow Shape
+
+```
+buildApplyWorkflow(RuntimeContext)
+  |
+  v
+[Step 1] check_blockers_checkpoint     (UNCHANGED)
+  |
+  v
+[Step 2] page_decision_loop            (NEW -- replaces execute_handler)
+  |
+  Internal loop (runs within execute()):
+  |
+  |  repeat:
+  |    1. PageObserver.observe(page)    -> PageSnapshot
+  |    2. buildDecisionContext()         -> DecisionContext
+  |    3. LLM decision call             -> DecisionAction
+  |    4. Platform guardrails           -> possibly override action
+  |    5. Execute via cascade           -> ActionResult
+  |    6. Record in action history
+  |    7. Check termination
+  |  until: terminal state
+```
+
+### 3.2 Why a Single Step (Not Per-Iteration Steps)
+
+**Arguments for per-iteration steps:**
+- Each page iteration becomes a durable checkpoint
+- Easier to inspect workflow history in Mastra dashboard
+
+**Arguments against (decisive):**
+- **Latency**: Mastra serialize/deserialize via PostgresStore adds ~150-300ms per step boundary. At 15 pages with multiple actions per page, this adds 5-10 seconds.
+- **Non-serializable state**: The Playwright Page, adapter, CostTracker, and Stagehand instance cannot be serialized. They are currently passed via closure through RuntimeContext. Making each iteration a step would require re-establishing browser context at each step boundary.
+- **Browser session continuity**: The browser session must stay alive across the entire loop. Mastra step boundaries are designed for points where the process can be suspended indefinitely.
+- **Precedent**: The current `execute_handler` already runs the entire SmartApplyHandler in a single step.
+
+**Decision**: Single step with internal loop. Suspend points for HITL are explicit `suspend()` calls at blocker detection points within the loop, exactly as `check_blockers_checkpoint` does today.
+
+### 3.3 HITL Suspend/Resume Within the Loop
+
+When the decision engine detects a blocker during page observation (or via the existing `BlockerDetector`), it suspends the workflow:
+
+```typescript
+// Inside page_decision_loop execute():
+if (observation.blockers.length > 0) {
+  // Update job status, notify VALET
+  await pauseJob(rt.supabase, state.jobId);
+  await sendNeedsHumanCallback(rt, state, blockerInfo);
+
+  state.hitl = { blocked: true, ... };
+  state.decisionLoop.lastObservation = serializeObservation(observation);
+
+  return await suspend({ blockerType, pageUrl });
+}
+```
+
+On resume, the step receives `resumeData`, injects the resolution (credentials, 2FA code), re-observes the page, and continues the loop.
+
+### 3.4 Decision Loop State Persistence
+
+The decision loop maintains state that must survive HITL suspend/resume but does NOT need to survive process crashes (the browser session is lost on crash anyway). This state lives in the WorkflowState schema (serializable):
+
+```typescript
+decisionLoop: z.object({
+  // Current iteration count
+  iteration: z.number().int().nonnegative().default(0),
+
+  // Page tracking
+  pagesProcessed: z.number().int().nonnegative().default(0),
+  currentPageFingerprint: z.string().nullable().default(null),
+  previousPageFingerprint: z.string().nullable().default(null),
+  samePageCount: z.number().int().nonnegative().default(0),
+
+  // Action history (last N actions for LLM context window)
+  actionHistory: z.array(z.object({
+    iteration: z.number(),
+    action: z.string(),        // e.g., "fill_form", "click_next", "login"
+    target: z.string(),        // e.g., "first_name field", "Next button"
+    result: z.enum(['success', 'partial', 'failed', 'skipped']),
+    layer: z.enum(['dom', 'stagehand', 'magnitude']).nullable(),
+    costUsd: z.number(),
+    durationMs: z.number(),
+    fieldsAttempted: z.number().optional(),
+    fieldsFilled: z.number().optional(),
+    pageFingerprint: z.string(),
+    timestamp: z.number(),
+  })).default([]),
+
+  // Cost tracking for budget enforcement
+  loopCostUsd: z.number().default(0),
+
+  // Termination
+  terminalState: z.enum([
+    'running',
+    'confirmation',
+    'review_page',
+    'submitted',
+    'stuck',
+    'budget_exceeded',
+    'error',
+    'max_iterations',
+  ]).default('running'),
+
+  terminationReason: z.string().nullable().default(null),
+})
+```
+
+---
+
+## 4. LLM Decision Call Design
+
+### 4.1 Model Selection
+
+| Quality Preset | Model | Cost/call | Rationale |
+|---|---|---|---|
+| `speed` | `claude-haiku-4-5-20251001` | ~$0.001 | Fast, cheap. Good enough for form-filling decisions on standard ATS sites. |
+| `balanced` | `claude-haiku-4-5-20251001` | ~$0.001 | Same model; quality comes from better prompting and more retries. |
+| `quality` | `claude-sonnet-4-20250514` | ~$0.003 | For complex/non-standard application forms where Haiku makes wrong decisions. |
+
+**Default: Haiku.** The decision call is a structured classification task with a constrained output schema. Haiku excels at this. Sonnet is reserved for the `quality` preset or when Haiku produces consecutive decision failures.
+
+### 4.2 Structured Output Format
+
+Use Anthropic's **tool_use** (function calling) to get constrained structured output. This is more reliable than JSON mode for enforcing the exact schema.
+
+```typescript
+const DECISION_TOOL = {
+  name: 'page_decision',
+  description: 'Decide the next action to take on the current page of a job application.',
+  input_schema: {
+    type: 'object',
+    required: ['action', 'reasoning'],
+    properties: {
+      action: {
+        type: 'string',
+        enum: [
+          'fill_form',          // Fill visible form fields with user data
+          'click_next',         // Click a navigation button (Next, Continue, Save & Continue)
+          'click_apply',        // Click an Apply button on a job listing
+          'click_submit',       // NEVER used autonomously -- only with user confirmation
+          'upload_resume',      // Trigger file upload for resume
+          'select_option',      // Select a specific dropdown/radio option
+          'dismiss_popup',      // Close a modal/popup/cookie banner
+          'scroll_down',        // Scroll to reveal more content
+          'login',              // Fill login credentials
+          'create_account',     // Fill account creation form
+          'enter_verification', // Enter 2FA/verification code
+          'wait_and_retry',     // Page is loading or transitioning
+          'stop_for_review',    // Stop and hand off to user for review
+          'mark_complete',      // Application appears submitted/confirmed
+          'report_blocked',     // Cannot proceed (CAPTCHA, unexpected state)
+        ],
+      },
+      reasoning: {
+        type: 'string',
+        description: 'Brief explanation of why this action was chosen (1-2 sentences).',
+      },
+      target: {
+        type: 'string',
+        description: 'What element or section to act on (e.g., "Next button", "email field", "resume upload").',
+      },
+      confidence: {
+        type: 'number',
+        description: 'Confidence in this decision (0.0 to 1.0).',
+        minimum: 0.0,
+        maximum: 1.0,
+      },
+      fields_to_fill: {
+        type: 'array',
+        description: 'For fill_form action: which field labels to prioritize.',
+        items: { type: 'string' },
+      },
+    },
+  },
+};
+```
+
+### 4.3 System Prompt Structure
+
+```
+SYSTEM PROMPT (cached, ~1200 tokens):
+
+You are a job application navigation agent. You observe the current state of
+a job application page and decide the single best next action.
+
+## Rules
+1. NEVER click Submit/Apply unless the action is 'click_apply' (for job listings)
+   or 'stop_for_review' (for review pages before submission).
+2. If the page has unfilled required fields, choose 'fill_form'.
+3. If all visible fields are filled and there is a Next/Continue button, choose 'click_next'.
+4. If you see a review/summary page, choose 'stop_for_review'.
+5. If you see a confirmation page ("application submitted"), choose 'mark_complete'.
+6. If you see a login form, choose 'login'.
+7. If you see CAPTCHA or a blocker you cannot handle, choose 'report_blocked'.
+8. Prefer the simplest action. Do not over-think.
+
+## Platform Guardrails
+{platform_guardrails}
+
+## User Profile Summary
+Name: {first_name} {last_name}
+Email: {email}
+(additional profile summary...)
+
+USER MESSAGE (per-iteration, ~500-2000 tokens):
+
+## Current Page State
+URL: {current_url}
+Page Type (detected): {page_type}
+Platform: {platform}
+Page Fingerprint: {fingerprint}
+
+## Visible Form Fields ({field_count} fields)
+{field_list_with_labels_types_values_required}
+
+## Visible Buttons
+{button_list}
+
+## Action History (last 5 actions)
+{recent_action_history}
+
+## Budget
+Spent: ${spent_usd} / ${budget_usd} remaining
+Iteration: {iteration} / {max_iterations}
+Same page count: {same_page_count}
+```
+
+### 4.4 Platform Guardrail Hints
+
+Platform guardrails are injected into the system prompt based on detected platform:
+
+```typescript
+const PLATFORM_GUARDRAILS: Record<string, string> = {
+  workday: `
+    - Workday uses multi-step SPAs. The URL rarely changes between pages.
+    - After filling a section, look for "Save & Continue" or section nav buttons.
+    - Workday dropdowns are custom (not native <select>). When filling, click the
+      dropdown trigger first, then select the option text.
+    - Never attempt to navigate away from the Workday iframe.
+  `,
+  greenhouse: `
+    - Greenhouse has a single-page form. Scroll down to find all sections.
+    - The Apply button may be at the top. After clicking, the page transforms
+      into a form without URL change.
+    - File upload is via a standard file input.
+  `,
+  lever: `
+    - Lever has a simple single-page form.
+    - Resume upload is usually the first field.
+    - EEO questions are at the bottom.
+  `,
+  // ... other platforms
+  other: `
+    - Unknown ATS platform. Proceed cautiously.
+    - Look for standard form patterns (text inputs, selects, file uploads).
+    - If stuck, scroll down to check for hidden content.
+  `,
+};
+```
+
+### 4.5 Decision Call Implementation
+
+```typescript
+// packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
+
+export interface DecisionContext {
+  url: string;
+  platform: string;
+  pageType: string;
+  fingerprint: string;
+  fields: FormFieldSummary[];
+  buttons: ButtonSummary[];
+  actionHistory: ActionHistoryEntry[];
+  budgetRemaining: number;
+  budgetTotal: number;
+  iteration: number;
+  maxIterations: number;
+  samePageCount: number;
+  profileSummary: string;
+}
+
+export interface DecisionResult {
+  action: DecisionAction;
+  reasoning: string;
+  target?: string;
+  confidence: number;
+  fieldsToFill?: string[];
+  tokenUsage: { input: number; output: number };
+  costUsd: number;
+  durationMs: number;
+}
+
+export class PageDecisionEngine {
+  private client: Anthropic;
+  private model: string;
+
+  constructor(config: { apiKey: string; model?: string }) {
+    this.client = new Anthropic({ apiKey: config.apiKey });
+    this.model = config.model || 'claude-haiku-4-5-20251001';
+  }
+
+  async decide(context: DecisionContext): Promise<DecisionResult> {
+    const start = Date.now();
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 300,
+      system: buildSystemPrompt(context),
+      messages: [{ role: 'user', content: buildUserMessage(context) }],
+      tools: [DECISION_TOOL],
+      tool_choice: { type: 'tool', name: 'page_decision' },
+    });
+
+    // Extract structured decision from tool_use response
+    const toolUse = response.content.find(b => b.type === 'tool_use');
+    // ... parse and validate ...
+  }
+}
+```
+
+---
+
+## 5. Execution Cascade Design
+
+### 5.1 Action Routing
+
+Each `DecisionAction` maps to an execution strategy that uses the three-tier cascade:
+
+```
+DecisionAction -> ActionExecutor -> DOM -> Stagehand -> Magnitude
+```
+
+| Decision Action | Primary Executor | Cascade Behavior |
+|---|---|---|
+| `fill_form` | SectionOrchestrator (v3) | DOMHand -> StagehandHand -> MagnitudeHand per field |
+| `click_next` | DOM click -> Stagehand act -> Magnitude act | Single element cascade |
+| `click_apply` | DOM click -> Stagehand act -> Magnitude act | Single element cascade |
+| `upload_resume` | DOM file input -> Stagehand act | File chooser handler pre-attached |
+| `select_option` | DOMHand -> StagehandHand | For dropdowns/radios |
+| `dismiss_popup` | DOM click -> Stagehand act | Target the close/dismiss button |
+| `scroll_down` | page.evaluate() scroll | No cascade needed ($0) |
+| `login` | formFiller credentials flow | Existing credential injection |
+| `create_account` | formFiller + credential generation | Existing account creation flow |
+| `enter_verification` | adapter.act() for code entry | HITL or auto-resolve |
+| `wait_and_retry` | setTimeout + re-observe | No action, just delay |
+
+### 5.2 SectionOrchestrator Integration for fill_form
+
+The existing `SectionOrchestrator` from v3 already implements the per-field escalation cascade. For `fill_form` actions:
+
+```typescript
+async executeFillForm(
+  page: Page,
+  adapter: BrowserAutomationAdapter,
+  userProfile: Record<string, unknown>,
+  ctx: LayerContext,
+): Promise<FillActionResult> {
+  // Reuse existing v3 layers
+  const domHand = new DOMHand();
+  const stagehandHand = new StagehandHand(adapter);
+  const magnitudeHand = new MagnitudeHand(adapter);
+
+  const orchestrator = new SectionOrchestrator(
+    [domHand, stagehandHand, magnitudeHand],
+    {
+      maxAttemptsPerLayer: 2,
+      layerOrder: ['dom', 'stagehand', 'magnitude'],
+      fastEscalationErrors: ['element_not_found', 'element_not_visible'],
+    },
+  );
+
+  return orchestrator.run(ctx);
+}
+```
+
+### 5.3 Single-Element Cascade (for clicks, navigation)
+
+```typescript
+async executeClickAction(
+  page: Page,
+  adapter: BrowserAutomationAdapter,
+  target: string,           // button text or selector hint from decision
+  actionType: string,       // 'click_next', 'click_apply', 'dismiss_popup'
+): Promise<ClickActionResult> {
+
+  // Tier 1: DOM — try to find and click by selector/text
+  const domResult = await tryDOMClick(page, target);
+  if (domResult.success) return { ...domResult, layer: 'dom', costUsd: 0 };
+
+  // Tier 2: Stagehand — semantic click via a11y tree
+  if (adapter.observe) {
+    const stagehandResult = await tryStagehandClick(adapter, target);
+    if (stagehandResult.success) return { ...stagehandResult, layer: 'stagehand', costUsd: 0.0005 };
+  }
+
+  // Tier 3: Magnitude — full vision agent click
+  const prompt = `Click the "${target}" button`;
+  await adapter.act(prompt);
+  return { success: true, layer: 'magnitude', costUsd: 0.005 };
+}
+```
+
+### 5.4 Timeout and Retry Policy
+
+| Layer | Per-Action Timeout | Max Retries | Escalation Trigger |
+|---|---|---|---|
+| DOM | 5s | 1 | element_not_found, element_not_visible |
+| Stagehand | 15s | 1 | timeout, element_not_interactable |
+| Magnitude | 30s | 0 | This is the last resort. Failures go to stuck detection. |
+
+**Global timeout per iteration**: 60s. If an iteration exceeds this, it is recorded as a failure and the decision engine decides whether to retry or give up.
+
+---
+
+## 6. Termination Conditions
+
+### 6.1 Termination Detection
+
+```typescript
+function checkTermination(
+  observation: PageSnapshot,
+  decision: DecisionResult,
+  loopState: DecisionLoopState,
+  budgetUsd: number,
+): TerminationResult | null {
+
+  // 1. Confirmation page — application submitted
+  if (decision.action === 'mark_complete') {
+    return { type: 'confirmation', reason: decision.reasoning };
+  }
+
+  // 2. Review page — stop for user review
+  if (decision.action === 'stop_for_review') {
+    return { type: 'review_page', reason: decision.reasoning };
+  }
+
+  // 3. Blocker — needs human intervention
+  if (decision.action === 'report_blocked') {
+    return { type: 'blocked', reason: decision.reasoning };
+  }
+
+  // 4. Stuck loop — same page fingerprint for too many iterations
+  if (loopState.samePageCount >= 6) {
+    return { type: 'stuck', reason: `Same page for ${loopState.samePageCount} iterations` };
+  }
+
+  // 5. Budget exceeded
+  if (loopState.loopCostUsd >= budgetUsd) {
+    return { type: 'budget_exceeded', reason: `Cost ${loopState.loopCostUsd} >= budget ${budgetUsd}` };
+  }
+
+  // 6. Max iterations
+  if (loopState.iteration >= MAX_ITERATIONS) {
+    return { type: 'max_iterations', reason: `Reached ${MAX_ITERATIONS} iterations` };
+  }
+
+  // 7. Error accumulation — 3+ consecutive failures
+  const recentFailures = loopState.actionHistory
+    .slice(-3)
+    .filter(a => a.result === 'failed');
+  if (recentFailures.length >= 3) {
+    return { type: 'error', reason: '3 consecutive action failures' };
+  }
+
+  return null; // Continue
+}
+```
+
+### 6.2 Termination Handling
+
+| Termination Type | WorkflowState.status | Job Status | VALET Callback |
+|---|---|---|---|
+| `confirmation` | `completed` | `completed` | `notifyCompleted` with success data |
+| `review_page` | `awaiting_review` | `awaiting_review` | `notifyAwaitingReview` |
+| `blocked` | `suspended` | `paused` | `notifyHumanNeeded` |
+| `stuck` | `awaiting_review` | `awaiting_review` | `notifyAwaitingReview` with stuck metadata |
+| `budget_exceeded` | `failed` | `failed` | `notifyFailed` with error_code: `budget_exceeded` |
+| `max_iterations` | `awaiting_review` | `awaiting_review` | `notifyAwaitingReview` with iteration data |
+| `error` | `failed` | `failed` | `notifyFailed` with error details |
+
+### 6.3 Confirmation Page Detection
+
+The LLM decides `mark_complete` based on page content signals, but we add heuristic verification:
+
+```typescript
+function verifyConfirmationPage(observation: PageSnapshot): boolean {
+  const bodyText = observation.bodyTextSnippet.toLowerCase();
+  const confirmationSignals = [
+    'application submitted',
+    'application received',
+    'thank you for applying',
+    'successfully submitted',
+    'your application has been',
+    'we have received your application',
+  ];
+  return confirmationSignals.some(signal => bodyText.includes(signal));
+}
+```
+
+---
+
+## 7. Desktop Entry Point Changes
+
+### 7.1 Current Desktop Path
+
+`runApplication()` in `packages/engine/src/runApplication.ts`:
+1. Launches magnitude-core browser agent directly
+2. Attempts cookbook replay
+3. Falls back to `agent.act(taskPrompt)` -- a single monolithic LLM call
+4. No Mastra, no decision engine, no structured observation
+
+### 7.2 New Desktop Path
+
+The desktop path gains a **decision engine mode** that runs the same observe-decide-act loop without Mastra (no Postgres needed):
+
+```typescript
+// packages/engine/src/runApplication.ts
+
+export async function runApplication(config: EngineConfig, params: RunParams): Promise<RunResult> {
+  // Feature flag: use decision engine or legacy path
+  if (config.useDecisionEngine) {
+    return runWithDecisionEngine(config, params);
+  }
+  return runLegacy(config, params);  // Current implementation
+}
+
+async function runWithDecisionEngine(config: EngineConfig, params: RunParams): Promise<RunResult> {
+  const { targetUrl, profile, resumePath, manualStore, onProgress } = params;
+  const emit = (type, message, extra) => onProgress({ type, message, timestamp: Date.now(), ...extra });
+
+  // 1. Launch browser (same as current)
+  const { startBrowserAgent } = await import('magnitude-core');
+  const agent = await startBrowserAgent({ url: targetUrl, ... });
+
+  // 2. Create decision engine (no Mastra/Postgres needed)
+  const decisionEngine = new PageDecisionEngine({
+    apiKey: config.anthropicApiKey,
+    model: config.model,
+  });
+
+  // 3. Create execution layers
+  // (DOM hand doesn't need adapter, Stagehand/Magnitude need the adapter wrapper)
+
+  // 4. Run decision loop (standalone, no Mastra)
+  const loopRunner = new DecisionLoopRunner({
+    decisionEngine,
+    page: agent.page,
+    profile: buildUserData(profile),
+    budget: config.budgetUsd ?? 1.0,
+    onProgress: emit,
+    manualStore,
+    resumePath,
+  });
+
+  const result = await loopRunner.run();
+
+  emit('complete', result.success ? 'Application filled' : `Failed: ${result.error}`);
+  return result;
+}
+```
+
+### 7.3 Minimal Engine Package Changes
+
+The engine package (`packages/engine`) needs:
+
+1. **New export**: `DecisionLoopRunner` -- a standalone (non-Mastra) version of the loop
+2. **New dependency**: The `PageDecisionEngine` class (shared between engine and ghosthands)
+3. **EngineConfig extension**: Add `useDecisionEngine?: boolean` and `budgetUsd?: number`
+
+The `DecisionLoopRunner` is a **pure logic class** that takes a Playwright Page, user profile, and decision engine. It does not depend on Mastra, Supabase, or any server-side infrastructure.
+
+### 7.4 Backward Compatibility
+
+- `EngineConfig.useDecisionEngine` defaults to `false`
+- The existing `runApplication()` path is unchanged
+- Desktop app can opt in by setting the flag
+- No changes to `LocalWorkerManager`, `GhostHandsBrokerClient`, or broker API
+
+---
+
+## 8. Worker Entry Point Changes
+
+### 8.1 Current Hosted Worker Path
+
+```
+jobExecutor.executeJob()
+  |-- execution_mode === 'mastra' --> executeMastraWorkflow()
+  |     |-- buildApplyWorkflow(rt)
+  |     |-- mastra.addWorkflow() / getWorkflow()
+  |     |-- run.start() / run.resume()
+  |     |-- HITL wait loop
+  |     |-- Finalization
+  |
+  |-- execution_mode !== 'mastra' --> legacy path
+        |-- handler.execute(ctx)
+        |-- Direct finalization
+```
+
+### 8.2 New Hosted Worker Path
+
+```
+jobExecutor.executeJob()
+  |-- execution_mode === 'mastra_decision' --> executeMastraWorkflow() (new workflow)
+  |     |-- buildApplyWorkflow(rt)  <-- now uses page_decision_loop step
+  |     |-- Same Mastra plumbing (unchanged)
+  |     |-- run.start() / run.resume()
+  |     |-- HITL wait loop (unchanged)
+  |     |-- Finalization (extended for decision loop metadata)
+  |
+  |-- execution_mode === 'mastra' --> executeMastraWorkflow() (current, SmartApplyHandler)
+  |
+  |-- execution_mode === 'smart_apply' | default --> legacy path
+```
+
+### 8.3 SmartApplyHandler as Fallback
+
+SmartApplyHandler is NOT removed. It remains available via:
+
+1. `execution_mode: 'smart_apply'` -- explicit legacy mode
+2. `execution_mode: 'mastra'` -- current Mastra path with SmartApplyHandler
+3. Feature flag `GH_DECISION_ENGINE_ENABLED=false` disables the new path globally
+
+The migration path:
+1. **Phase 1**: `mastra_decision` is opt-in via execution_mode
+2. **Phase 2**: `mastra_decision` becomes default for `mastra` mode, old handler becomes `mastra_legacy`
+3. **Phase 3**: SmartApplyHandler deprecated, decision engine is the only path
+
+### 8.4 Finalization Changes
+
+The existing finalization logic in `executeMastraWorkflow()` extracts `WorkflowState` from the Mastra result and maps it to job status. The decision loop adds new metadata:
+
+```typescript
+// In finalization, after extracting finalState:
+if (finalState.decisionLoop) {
+  const dl = finalState.decisionLoop;
+  // Persist decision engine metrics
+  await this.supabase
+    .from('gh_automation_jobs')
+    .update({
+      metadata: {
+        ...job.metadata,
+        decision_engine: {
+          iterations: dl.iteration,
+          pages_processed: dl.pagesProcessed,
+          terminal_state: dl.terminalState,
+          total_actions: dl.actionHistory.length,
+          cost_breakdown: {
+            decision_calls: dl.actionHistory.filter(a => a.action === 'decision').length,
+            dom_actions: dl.actionHistory.filter(a => a.layer === 'dom').length,
+            stagehand_actions: dl.actionHistory.filter(a => a.layer === 'stagehand').length,
+            magnitude_actions: dl.actionHistory.filter(a => a.layer === 'magnitude').length,
+          },
+        },
+      },
+    })
+    .eq('id', job.id);
+}
+```
+
+---
+
+## 9. Workflow State Schema Changes
+
+### 9.1 Extended WorkflowState (types.ts)
+
+```typescript
+export const workflowState = z.object({
+  // ... existing fields unchanged ...
+  jobId: z.string().uuid(),
+  userId: z.string().uuid(),
+  targetUrl: z.string().url(),
+  platform: z.string().default('other'),
+  qualityPreset: z.enum(['speed', 'balanced', 'quality']),
+  budgetUsd: z.number(),
+  handler: z.object({ /* unchanged */ }),
+  hitl: z.object({ /* unchanged */ }),
+  metrics: z.object({ /* unchanged */ }),
+  status: z.enum([ /* unchanged */ ]),
+
+  // NEW: Decision loop state
+  decisionLoop: z.object({
+    iteration: z.number().int().nonnegative().default(0),
+    pagesProcessed: z.number().int().nonnegative().default(0),
+    currentPageFingerprint: z.string().nullable().default(null),
+    previousPageFingerprint: z.string().nullable().default(null),
+    samePageCount: z.number().int().nonnegative().default(0),
+    actionHistory: z.array(z.object({
+      iteration: z.number(),
+      action: z.string(),
+      target: z.string(),
+      result: z.enum(['success', 'partial', 'failed', 'skipped']),
+      layer: z.enum(['dom', 'stagehand', 'magnitude']).nullable(),
+      costUsd: z.number(),
+      durationMs: z.number(),
+      fieldsAttempted: z.number().optional(),
+      fieldsFilled: z.number().optional(),
+      pageFingerprint: z.string(),
+      timestamp: z.number(),
+    })).default([]),
+    loopCostUsd: z.number().default(0),
+    terminalState: z.enum([
+      'running', 'confirmation', 'review_page', 'submitted',
+      'stuck', 'budget_exceeded', 'error', 'max_iterations',
+    ]).default('running'),
+    terminationReason: z.string().nullable().default(null),
+  }).optional(), // Optional for backward compat with existing execute_handler step
+});
+```
+
+### 9.2 Trimming Action History
+
+To keep serialized state within reasonable bounds (Mastra stores in Postgres):
+
+- Maximum 50 entries in `actionHistory`
+- Oldest entries are evicted when the array exceeds 50
+- LLM context window only receives the last 10 entries
+
+---
+
+## 10. File Changes Inventory
+
+### 10.1 New Files to Create
+
+| File | Purpose |
+|---|---|
+| `packages/ghosthands/src/engine/decision/PageDecisionEngine.ts` | LLM decision call implementation |
+| `packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts` | Standalone decision loop (shared by Mastra and desktop) |
+| `packages/ghosthands/src/engine/decision/types.ts` | DecisionAction, DecisionContext, DecisionResult types |
+| `packages/ghosthands/src/engine/decision/prompts.ts` | System prompt builder, platform guardrails |
+| `packages/ghosthands/src/engine/decision/terminationDetector.ts` | Termination condition checks |
+| `packages/ghosthands/src/engine/decision/actionExecutor.ts` | Routes DecisionAction to execution cascade |
+| `packages/ghosthands/src/engine/decision/pageSnapshotBuilder.ts` | Builds DecisionContext from page observation |
+| `packages/ghosthands/src/engine/decision/index.ts` | Barrel export |
+| `packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts` | New Mastra step wrapping the loop |
+| `packages/ghosthands/src/__tests__/unit/engine/decision/pageDecisionEngine.test.ts` | Unit tests |
+| `packages/ghosthands/src/__tests__/unit/engine/decision/terminationDetector.test.ts` | Unit tests |
+| `packages/ghosthands/src/__tests__/unit/engine/decision/actionExecutor.test.ts` | Unit tests |
+
+### 10.2 Files to Modify
+
+| File | Changes |
+|---|---|
+| `packages/ghosthands/src/workflows/mastra/types.ts` | Add `decisionLoop` to WorkflowState schema |
+| `packages/ghosthands/src/workflows/mastra/applyWorkflow.ts` | Add `page_decision_loop` step, make `execute_handler` conditional |
+| `packages/ghosthands/src/workflows/mastra/steps/factory.ts` | Add `buildPageDecisionLoop()` step builder |
+| `packages/ghosthands/src/workers/jobExecutor.ts` | Add `mastra_decision` execution_mode routing, extend finalization |
+| `packages/engine/src/types.ts` | Add `useDecisionEngine`, `budgetUsd` to EngineConfig |
+| `packages/engine/src/runApplication.ts` | Add `runWithDecisionEngine()` path |
+| `packages/engine/src/index.ts` | Export decision engine types |
+
+### 10.3 Files to Deprecate (not remove)
+
+| File | Status |
+|---|---|
+| `packages/ghosthands/src/workers/taskHandlers/smartApplyHandler.ts` | Mark as `@deprecated` in Phase 3. Still used by `mastra` and `smart_apply` execution modes. |
+
+---
+
+## 11. Migration Path
+
+### Phase 1: Build and Shadow Test (2-3 weeks)
+
+1. Implement `PageDecisionEngine`, `DecisionLoopRunner`, `actionExecutor`
+2. Create `page_decision_loop` Mastra step
+3. Wire `execution_mode: 'mastra_decision'` in jobExecutor
+4. Add feature flag `GH_DECISION_ENGINE_ENABLED` (default: false)
+5. Shadow test: run decision engine alongside SmartApplyHandler, log decisions without executing
+6. Compare decision accuracy against SmartApplyHandler's actual actions
+
+**Rollout**: Internal testing only. All production jobs use SmartApplyHandler.
+
+### Phase 2: Opt-In with Guardrails (1-2 weeks)
+
+1. Enable `mastra_decision` for specific platforms (start with greenhouse, lever -- simpler ATS)
+2. Add per-user opt-in via execution_mode in job creation
+3. Monitor: decision accuracy, cost per job, completion rate, stuck rate
+4. Add auto-fallback: if decision engine fails 3x, fall back to SmartApplyHandler for the job
+
+**Rollout**: 10% of jobs on supported platforms.
+
+### Phase 3: Default Path (1-2 weeks)
+
+1. Make `mastra_decision` the default for `execution_mode: 'mastra'`
+2. SmartApplyHandler available via `execution_mode: 'smart_apply_legacy'`
+3. Monitor for regressions
+
+**Rollout**: 100% of new jobs.
+
+### Phase 4: Desktop Integration (parallel)
+
+1. Add `useDecisionEngine` to desktop EngineConfig
+2. Wire `DecisionLoopRunner` in `runApplication()`
+3. Desktop app opts in via settings toggle
+
+---
+
+## 12. Risk Assessment
+
+### 12.1 High Risk
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **LLM decision hallucination** | Wrong action (e.g., clicking Submit instead of Next) | Constrained tool_use schema; guardrail layer that blocks `click_submit` unless explicit user confirmation; heuristic double-check on dangerous actions |
+| **Cost regression** | Decision engine LLM calls add cost on top of execution | Haiku is ~$0.001/call; budget cap enforced; monitor cost per job vs SmartApplyHandler baseline |
+| **Latency regression** | Extra LLM call per iteration adds 500-1000ms | Haiku latency is 300-500ms; decision call runs in parallel with page load observation; overall latency should be comparable since SmartApplyHandler also makes LLM calls for form filling |
+
+### 12.2 Medium Risk
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **v3 layers not production-ready** | DOMHand/StagehandHand/MagnitudeHand may have bugs | SmartApplyHandler's `fillFormOnPage()` already uses similar DOM + Magnitude fallback patterns; v3 layers were tested in isolation; gradual rollout catches issues early |
+| **WorkflowState size bloat** | Action history grows large for complex applications | Cap at 50 entries; trim old entries; decision LLM only sees last 10 |
+| **HITL resume breaks** | Decision loop state may be inconsistent after resume | Re-observe page on resume (browser state is ground truth); action history persists correctly in WorkflowState |
+
+### 12.3 Low Risk
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **Desktop path regression** | `useDecisionEngine` flag off by default | No change to existing desktop behavior unless opted in |
+| **Backward compatibility** | New WorkflowState fields | `decisionLoop` is optional in schema; existing `execute_handler` step ignores it |
+
+---
+
+## 13. Appendix: Sequence Diagrams
+
+### 13.1 Page Decision Loop — Happy Path
+
+```
+JobExecutor                Mastra Workflow          PageDecisionLoop Step         DecisionEngine          ActionExecutor
+    |                           |                           |                           |                      |
+    |-- executeMastraWorkflow() |                           |                           |                      |
+    |                           |                           |                           |                      |
+    |                    [Step 1: check_blockers]           |                           |                      |
+    |                           |--- no blocker ----------->|                           |                      |
+    |                           |                           |                           |                      |
+    |                    [Step 2: page_decision_loop]       |                           |                      |
+    |                           |                           |                           |                      |
+    |                           |                    [Iteration 1]                      |                      |
+    |                           |                           |--- observe(page) -------->|                      |
+    |                           |                           |<-- PageSnapshot ----------|                      |
+    |                           |                           |                           |                      |
+    |                           |                           |--- decide(context) ------>|                      |
+    |                           |                           |<-- {fill_form, ...} ------|                      |
+    |                           |                           |                           |                      |
+    |                           |                           |--- execute(fill_form) ----|----> DOMHand.execute()
+    |                           |                           |                           |  (fields filled via DOM)
+    |                           |                           |<-- {success, 5 filled} ---|<---- result
+    |                           |                           |                           |                      |
+    |                           |                           |--- checkTermination() --->|                      |
+    |                           |                           |<-- null (continue) -------|                      |
+    |                           |                           |                           |                      |
+    |                           |                    [Iteration 2]                      |                      |
+    |                           |                           |--- observe(page) -------->|                      |
+    |                           |                           |<-- PageSnapshot ----------|                      |
+    |                           |                           |                           |                      |
+    |                           |                           |--- decide(context) ------>|                      |
+    |                           |                           |<-- {click_next, ...} -----|                      |
+    |                           |                           |                           |                      |
+    |                           |                           |--- execute(click_next) ---|----> tryDOMClick()
+    |                           |                           |                           |  (Next button clicked)
+    |                           |                           |<-- {success} -------------|<---- result
+    |                           |                           |                           |                      |
+    |                           |                    [... more iterations ...]          |                      |
+    |                           |                           |                           |                      |
+    |                           |                    [Iteration N]                      |                      |
+    |                           |                           |--- decide(context) ------>|                      |
+    |                           |                           |<-- {stop_for_review} -----|                      |
+    |                           |                           |                           |                      |
+    |                           |                           |--- checkTermination() --->|                      |
+    |                           |                           |<-- {review_page} ---------|                      |
+    |                           |                           |                           |                      |
+    |                           |<-- state.status = 'awaiting_review' ----              |                      |
+    |                           |                           |                           |                      |
+    |<-- finalize result -------|                           |                           |                      |
+```
+
+### 13.2 Page Decision Loop — HITL Suspend/Resume
+
+```
+PageDecisionLoop Step         BlockerDetector          Mastra Engine              JobExecutor (HITL wait)
+    |                              |                       |                           |
+    |  [Iteration 3]              |                       |                           |
+    |--- observe(page) ---------->|                       |                           |
+    |<-- blockers: [captcha] -----|                       |                           |
+    |                              |                       |                           |
+    |  (update state, notify VALET)                       |                           |
+    |--- suspend({captcha}) ----->|                       |                           |
+    |                              |--- serialize state -->|                           |
+    |                              |                       |--- result.status='suspended'
+    |                              |                       |                           |
+    |                              |                       |    [wait for human...]    |
+    |                              |                       |    [LISTEN/NOTIFY]        |
+    |                              |                       |    [human solves captcha] |
+    |                              |                       |                           |
+    |                              |                       |<-- resume(resolutionType) |
+    |<-- resumeData={manual} -----|                       |                           |
+    |                              |                       |                           |
+    |  [Re-enter loop]            |                       |                           |
+    |--- injectResolution() ----->|                       |                           |
+    |--- re-observe(page) ------->|                       |                           |
+    |<-- no blockers -------------|                       |                           |
+    |                              |                       |                           |
+    |  [Continue from iteration 3]|                       |                           |
+    |--- decide(context) -------->|                       |                           |
+    |                              |                       |                           |
+```
+
+### 13.3 Desktop Path — Decision Engine
+
+```
+Desktop App              runApplication()           DecisionLoopRunner          PageDecisionEngine
+    |                         |                           |                           |
+    |-- runApplication({      |                           |                           |
+    |     useDecisionEngine:  |                           |                           |
+    |     true, ...})         |                           |                           |
+    |                         |                           |                           |
+    |                  [Launch browser]                   |                           |
+    |                         |                           |                           |
+    |                  [Create DecisionLoopRunner]        |                           |
+    |                         |--- run() --------------->|                           |
+    |                         |                           |                           |
+    |                         |                    [Same loop as hosted,             |
+    |                         |                     but no Mastra, no Postgres,      |
+    |                         |                     no HITL suspend]                 |
+    |                         |                           |                           |
+    |                         |                    [Iteration 1..N]                  |
+    |                         |                           |--- decide() ------------>|
+    |                         |                           |<-- action ---------------|
+    |                         |                           |--- execute(action) ----->|
+    |<-- onProgress events ---|<-- emit() ---------------|                           |
+    |                         |                           |                           |
+    |                         |<-- RunResult -------------|                           |
+    |<-- result --------------|                           |                           |
+```
+
+### 13.4 Execution Cascade — Per Field
+
+```
+ActionExecutor          DOMHand              StagehandHand          MagnitudeHand
+    |                      |                      |                      |
+    |  [fill "email" field]|                      |                      |
+    |--- execute() ------->|                      |                      |
+    |                      |-- nativeInputValue() |                      |
+    |                      |-- dispatchEvent()    |                      |
+    |                      |-- verify readback()  |                      |
+    |                      |                      |                      |
+    |  (Case A: DOM succeeds)                     |                      |
+    |<-- {success, layer:'dom', cost:$0} ---------|                      |
+    |                      |                      |                      |
+    |  (Case B: DOM fails — element not found)    |                      |
+    |                      |--- escalate -------->|                      |
+    |                      |                      |-- observe('email')   |
+    |                      |                      |-- act('fill email')  |
+    |                      |                      |-- verify readback()  |
+    |                      |                      |                      |
+    |  (Case B success)    |                      |                      |
+    |<-- {success, layer:'stagehand', cost:$0.0005}                     |
+    |                      |                      |                      |
+    |  (Case C: Stagehand fails — custom widget)  |                      |
+    |                      |                      |--- escalate -------->|
+    |                      |                      |                      |-- act('Type email')
+    |                      |                      |                      |-- screenshot verify
+    |                      |                      |                      |
+    |  (Case C success)    |                      |                      |
+    |<-- {success, layer:'magnitude', cost:$0.005}|                      |
+```
+
+---
+
+## Appendix: Constants
+
+```typescript
+// Decision loop limits
+const MAX_ITERATIONS = 100;          // Absolute maximum loop iterations
+const MAX_FORM_PAGES = 15;           // Maximum form pages (matches SmartApplyHandler)
+const MAX_SAME_PAGE_COUNT = 6;       // Stuck detection threshold
+const MAX_CONSECUTIVE_FAILURES = 3;  // Error accumulation threshold
+const MAX_ACTION_HISTORY = 50;       // Action history cap in WorkflowState
+const LLM_CONTEXT_HISTORY = 10;      // Actions sent to LLM for context
+
+// Timeouts
+const DOM_ACTION_TIMEOUT_MS = 5_000;
+const STAGEHAND_ACTION_TIMEOUT_MS = 15_000;
+const MAGNITUDE_ACTION_TIMEOUT_MS = 30_000;
+const ITERATION_TIMEOUT_MS = 60_000;
+const PAGE_LOAD_WAIT_MS = 3_000;
+
+// Cost
+const DECISION_CALL_COST_ESTIMATE = 0.001;  // Haiku decision call
+const DOM_ACTION_COST = 0;
+const STAGEHAND_ACTION_COST = 0.0005;
+const MAGNITUDE_ACTION_COST = 0.005;
+```

--- a/docs/VALET-INTEGRATION-CONTRACT.md
+++ b/docs/VALET-INTEGRATION-CONTRACT.md
@@ -191,7 +191,7 @@ Rich application request with full profile data.
 | `quality` | enum | No | balanced | speed, balanced, quality (maps to budget tier) |
 | `model` | string | No | qwen-72b | LLM model alias for reasoning (see Model Reference) |
 | `image_model` | string | No | same as model | Separate vision model for screenshots (must have vision support) |
-| `execution_mode` | enum | No | auto | auto, ai_only, cookbook_only |
+| `execution_mode` | enum | No | auto | auto, ai_only, hybrid, smart_apply, agent_apply, mastra, mastra_decision |
 | `priority` | 1-10 | No | 5 | Higher = processed sooner |
 | `timeout_seconds` | 30-1800 | No | 300 | Max execution time |
 | `idempotency_key` | string | No | - | Prevents duplicate submissions |
@@ -263,6 +263,8 @@ All SiliconFlow-hosted models (qwen*) use your existing `SILICONFLOW_API_KEY` �
 | `auto` | Check ManualStore for cookbook → replay if healthy → fallback to Magnitude AI |
 | `ai_only` | Skip cookbook lookup, always use Magnitude LLM exploration |
 | `cookbook_only` | Use cookbook only — fail if no manual exists or health < 30% |
+| `mastra` | Mastra workflow with SmartApplyHandler (current default for hosted workers) |
+| `mastra_decision` | Mastra workflow with text-first decision engine (observe→decide→act loop using LLM tool_use). Opt-in per job. Uses a three-tier execution cascade: DOM ($0) → Stagehand → Magnitude. Supports HITL suspend/resume for blockers detected during the loop. Returns `decision_engine` metadata in completion callbacks. |
 
 ### 4.1.3 Worker Selection
 

--- a/packages/ghosthands/src/api/schemas/valet.ts
+++ b/packages/ghosthands/src/api/schemas/valet.ts
@@ -72,7 +72,7 @@ export const ValetApplySchema = z.object({
   worker_affinity: z.enum(['strict', 'preferred', 'any']).default('preferred'),
   model: z.string().max(100).optional().describe('LLM model alias (e.g. "qwen-72b", "deepseek-chat", "claude-sonnet")'),
   image_model: z.string().max(100).optional().describe('Separate model for vision/screenshot analysis'),
-  execution_mode: z.enum(['auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra']).default('auto'),
+  execution_mode: z.enum(['auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra', 'mastra_decision']).default('auto'),
 });
 
 export type ValetApplyInput = z.infer<typeof ValetApplySchema>;
@@ -96,7 +96,7 @@ export const ValetTaskSchema = z.object({
   worker_affinity: z.enum(['strict', 'preferred', 'any']).default('preferred'),
   model: z.string().max(100).optional().describe('LLM model alias (e.g. "qwen-72b", "deepseek-chat", "claude-sonnet")'),
   image_model: z.string().max(100).optional().describe('Separate model for vision/screenshot analysis'),
-  execution_mode: z.enum(['auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra']).default('auto'),
+  execution_mode: z.enum(['auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra', 'mastra_decision']).default('auto'),
 });
 
 export type ValetTaskInput = z.infer<typeof ValetTaskSchema>;

--- a/packages/ghosthands/src/db/migrations/027_add_mastra_decision_mode.sql
+++ b/packages/ghosthands/src/db/migrations/027_add_mastra_decision_mode.sql
@@ -1,0 +1,16 @@
+-- Add 'mastra_decision' to the execution_mode CHECK constraint.
+-- This allows the decision-engine Mastra workflow to be activated per-job.
+
+ALTER TABLE gh_automation_jobs
+  DROP CONSTRAINT IF EXISTS gh_automation_jobs_execution_mode_check;
+
+ALTER TABLE gh_automation_jobs
+  ADD CONSTRAINT gh_automation_jobs_execution_mode_check
+    CHECK (execution_mode IN ('auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra', 'mastra_decision'));
+
+-- Rollback:
+--   ALTER TABLE gh_automation_jobs
+--     DROP CONSTRAINT IF EXISTS gh_automation_jobs_execution_mode_check;
+--   ALTER TABLE gh_automation_jobs
+--     ADD CONSTRAINT gh_automation_jobs_execution_mode_check
+--       CHECK (execution_mode IN ('auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra'));

--- a/packages/ghosthands/src/db/migrations/027_add_mastra_decision_mode.sql
+++ b/packages/ghosthands/src/db/migrations/027_add_mastra_decision_mode.sql
@@ -1,4 +1,4 @@
--- Add 'mastra_decision' to the execution_mode CHECK constraint.
+-- Add 'mastra_decision' to execution_mode and final_mode CHECK constraints.
 -- This allows the decision-engine Mastra workflow to be activated per-job.
 
 ALTER TABLE gh_automation_jobs
@@ -8,9 +8,21 @@ ALTER TABLE gh_automation_jobs
   ADD CONSTRAINT gh_automation_jobs_execution_mode_check
     CHECK (execution_mode IN ('auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra', 'mastra_decision'));
 
+ALTER TABLE gh_automation_jobs
+  DROP CONSTRAINT IF EXISTS gh_automation_jobs_final_mode_check;
+
+ALTER TABLE gh_automation_jobs
+  ADD CONSTRAINT gh_automation_jobs_final_mode_check
+    CHECK (final_mode IN ('magnitude', 'hybrid', 'smart_apply', 'agent_apply', 'mastra', 'mastra_decision'));
+
 -- Rollback:
 --   ALTER TABLE gh_automation_jobs
 --     DROP CONSTRAINT IF EXISTS gh_automation_jobs_execution_mode_check;
 --   ALTER TABLE gh_automation_jobs
 --     ADD CONSTRAINT gh_automation_jobs_execution_mode_check
 --       CHECK (execution_mode IN ('auto', 'ai_only', 'hybrid', 'smart_apply', 'agent_apply', 'mastra'));
+--   ALTER TABLE gh_automation_jobs
+--     DROP CONSTRAINT IF EXISTS gh_automation_jobs_final_mode_check;
+--   ALTER TABLE gh_automation_jobs
+--     ADD CONSTRAINT gh_automation_jobs_final_mode_check
+--       CHECK (final_mode IN ('magnitude', 'hybrid', 'smart_apply', 'agent_apply', 'mastra'));

--- a/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
+++ b/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
@@ -198,7 +198,20 @@ export class DecisionLoopRunner {
           message: 'Building page snapshot.',
         });
 
-        const snapshot = await this.snapshotBuilder.buildSnapshot(this.page, loopState.actionHistory);
+        let snapshot = await this.snapshotBuilder.buildSnapshot(this.page, loopState.actionHistory);
+        if (snapshot.fields.length === 0 && snapshot.buttons.length === 0 && loopState.iteration > 0) {
+          await new Promise((r) => setTimeout(r, 2000));
+          await this.page.waitForLoadState('domcontentloaded', { timeout: 3000 }).catch(() => {});
+          const retrySnapshot = await this.snapshotBuilder.buildSnapshot(this.page, loopState.actionHistory);
+          if (retrySnapshot.fields.length > 0 || retrySnapshot.buttons.length > 0) {
+            snapshot = retrySnapshot;
+            this.emit({
+              type: 'observe',
+              iteration: loopState.iteration,
+              message: `[decision-loop] re-observation recovered: fields=${snapshot.fields.length} buttons=${snapshot.buttons.length}`,
+            });
+          }
+        }
         loopState.previousPageFingerprint = loopState.currentPageFingerprint;
         loopState.currentPageFingerprint = snapshot.fingerprint.hash;
         const pageChanged = loopState.previousPageFingerprint !== loopState.currentPageFingerprint;
@@ -288,6 +301,9 @@ export class DecisionLoopRunner {
         if (executorResult.pageNavigated) {
           await this.page.waitForLoadState('domcontentloaded', { timeout: 2000 }).catch(() => {});
           await sleep(2000);
+        }
+        if (executorResult.pageNavigated || executorResult.status === 'action_succeeded') {
+          await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
         }
       }
     } catch (error) {

--- a/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
+++ b/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
@@ -1,4 +1,5 @@
 import type { BrowserAutomationAdapter } from '../../adapters/types';
+import type { CostTracker } from '../../workers/costControl';
 import type { AnthropicClientConfig } from '../../workers/taskHandlers/types';
 import type { Page } from 'playwright';
 import { ActionExecutor } from './actionExecutor';
@@ -120,6 +121,7 @@ export class DecisionLoopRunner {
   private readonly profile: Record<string, any>;
   private readonly platform: string;
   private readonly budgetUsd: number;
+  private readonly costTracker?: CostTracker;
   private readonly onProgress?: (event: ProgressEvent) => void;
   private readonly maxIterations: number;
   private readonly snapshotBuilder: PageSnapshotBuilder;
@@ -135,6 +137,7 @@ export class DecisionLoopRunner {
     profile: Record<string, any>;
     platform: string;
     budgetUsd: number;
+    costTracker?: CostTracker;
     anthropicConfig?: AnthropicClientConfig;
     model?: string;
     onProgress?: (event: { type: string; message: string; iteration: number }) => void;
@@ -147,12 +150,21 @@ export class DecisionLoopRunner {
     this.profile = config.profile;
     this.platform = config.platform;
     this.budgetUsd = config.budgetUsd;
+    this.costTracker = config.costTracker;
     this.onProgress = config.onProgress;
     this.maxIterations = Math.max(1, Math.min(config.maxIterations ?? MAX_ITERATIONS, MAX_ITERATIONS));
     this.snapshotBuilder = new PageSnapshotBuilder(config.platform);
     this.decisionEngine = new PageDecisionEngine({
       anthropicConfig: config.anthropicConfig,
       model: config.model,
+      onTokenUsage: config.costTracker
+        ? (usage) => {
+            config.costTracker!.recordTokenUsage({
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+            });
+          }
+        : undefined,
     });
     this.actionExecutor = new ActionExecutor(config.page, config.adapter);
     this.profileSummary = summarizeProfile(config.profile);
@@ -208,7 +220,8 @@ export class DecisionLoopRunner {
           this.profileSummary,
           this.platform,
         );
-        loopState.loopCostUsd += decisionResult.costUsd;
+        // Cost is tracked by CostTracker via onTokenUsage callback (decision calls)
+        // and adapter tokensUsed events (Stagehand/Magnitude calls).
 
         const guardedDecision = this.applyGuardrails(decisionResult, snapshot);
         this.emit({
@@ -218,7 +231,12 @@ export class DecisionLoopRunner {
         });
 
         const executorResult = await this.actionExecutor.execute(guardedDecision, snapshot);
-        loopState.loopCostUsd += executorResult.costUsd;
+
+        // Sync loopCostUsd from CostTracker if available (real costs),
+        // otherwise it stays at 0 (costs still tracked externally).
+        if (this.costTracker) {
+          loopState.loopCostUsd = this.costTracker.getSnapshot().totalCost;
+        }
 
         const historyEntry: ActionHistoryEntry = {
           iteration: loopState.iteration,
@@ -226,7 +244,7 @@ export class DecisionLoopRunner {
           target: guardedDecision.target || '',
           result: deriveActionResult(guardedDecision, executorResult),
           layer: executorResult.layer,
-          costUsd: decisionResult.costUsd + executorResult.costUsd,
+          costUsd: 0, // Real cost tracked by CostTracker, not per-action estimates
           durationMs: decisionResult.durationMs + executorResult.durationMs,
           fieldsAttempted: executorResult.fieldsAttempted,
           fieldsFilled: executorResult.fieldsFilled,

--- a/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
+++ b/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
@@ -1,0 +1,362 @@
+import type { BrowserAutomationAdapter } from '../../adapters/types';
+import type { AnthropicClientConfig } from '../../workers/taskHandlers/types';
+import type { Page } from 'playwright';
+import { ActionExecutor } from './actionExecutor';
+import { PageDecisionEngine } from './PageDecisionEngine';
+import { PageSnapshotBuilder } from './pageSnapshotBuilder';
+import { MAX_ITERATIONS, checkTermination } from './terminationDetector';
+import type {
+  ActionHistoryEntry,
+  DecisionAction,
+  DecisionLoopState,
+  ExecutorResult,
+} from './types';
+import { DecisionLoopStateSchema } from './types';
+
+const ACTION_HISTORY_LIMIT = 25;
+const SENSITIVE_PROFILE_KEY = /password|secret|token|cookie|session|credential|auth|api[-_]?key/i;
+
+type ProgressEvent = {
+  type: string;
+  message: string;
+  iteration: number;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeText(value: string | undefined | null): string {
+  return (value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function summarizeProfile(profile: Record<string, any>): string {
+  const lines: string[] = [];
+
+  for (const [key, value] of Object.entries(profile || {})) {
+    if (!key || key.startsWith('_') || SENSITIVE_PROFILE_KEY.test(key)) continue;
+    if (value === null || value === undefined) continue;
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) continue;
+      lines.push(`${key}: ${trimmed.slice(0, 240)}`);
+      continue;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      lines.push(`${key}: ${String(value)}`);
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      const rendered = value
+        .map((entry) => {
+          if (typeof entry === 'string') return entry.trim();
+          if (typeof entry === 'number' || typeof entry === 'boolean') return String(entry);
+          if (entry && typeof entry === 'object') {
+            return JSON.stringify(redactSensitiveObject(entry)).slice(0, 200);
+          }
+          return '';
+        })
+        .filter(Boolean)
+        .slice(0, 6)
+        .join('; ');
+      if (rendered) lines.push(`${key}: ${rendered}`);
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      const redacted = JSON.stringify(redactSensitiveObject(value)).slice(0, 300);
+      if (redacted && redacted !== '{}') lines.push(`${key}: ${redacted}`);
+    }
+  }
+
+  return lines.join('\n').slice(0, 4000);
+}
+
+function redactSensitiveObject(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveObject(entry));
+  }
+
+  if (!value || typeof value !== 'object') return value;
+
+  const output: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (SENSITIVE_PROFILE_KEY.test(key)) continue;
+    output[key] = redactSensitiveObject(entry);
+  }
+  return output;
+}
+
+function deriveActionResult(decision: DecisionAction, executorResult: ExecutorResult): ActionHistoryEntry['result'] {
+  if (
+    decision.action === 'stop_for_review' ||
+    decision.action === 'mark_complete' ||
+    decision.action === 'report_blocked'
+  ) {
+    return 'skipped';
+  }
+
+  if (executorResult.status === 'action_succeeded') {
+    if (
+      executorResult.fieldsAttempted > 0 &&
+      executorResult.fieldsFilled > 0 &&
+      executorResult.fieldsFilled < executorResult.fieldsAttempted
+    ) {
+      return 'partial';
+    }
+    return 'success';
+  }
+
+  if (executorResult.status === 'needs_review') return 'skipped';
+  return 'failed';
+}
+
+export class DecisionLoopRunner {
+  private readonly page: Page;
+  private readonly adapter: BrowserAutomationAdapter;
+  private readonly profile: Record<string, any>;
+  private readonly platform: string;
+  private readonly budgetUsd: number;
+  private readonly onProgress?: (event: ProgressEvent) => void;
+  private readonly maxIterations: number;
+  private readonly snapshotBuilder: PageSnapshotBuilder;
+  private readonly decisionEngine: PageDecisionEngine;
+  private readonly actionExecutor: ActionExecutor;
+  private readonly profileSummary: string;
+
+  constructor(config: {
+    page: Page;
+    adapter: BrowserAutomationAdapter;
+    profile: Record<string, any>;
+    platform: string;
+    budgetUsd: number;
+    anthropicConfig?: AnthropicClientConfig;
+    model?: string;
+    onProgress?: (event: { type: string; message: string; iteration: number }) => void;
+    maxIterations?: number;
+  }) {
+    this.page = config.page;
+    this.adapter = config.adapter;
+    this.profile = config.profile;
+    this.platform = config.platform;
+    this.budgetUsd = config.budgetUsd;
+    this.onProgress = config.onProgress;
+    this.maxIterations = Math.max(1, Math.min(config.maxIterations ?? MAX_ITERATIONS, MAX_ITERATIONS));
+    this.snapshotBuilder = new PageSnapshotBuilder(config.platform);
+    this.decisionEngine = new PageDecisionEngine({
+      anthropicConfig: config.anthropicConfig,
+      model: config.model,
+    });
+    this.actionExecutor = new ActionExecutor(config.page, config.adapter);
+    this.profileSummary = summarizeProfile(config.profile);
+  }
+
+  async run(): Promise<{
+    success: boolean;
+    terminalState: string;
+    terminationReason: string;
+    loopState: DecisionLoopState;
+  }> {
+    const loopState: DecisionLoopState = DecisionLoopStateSchema.parse({
+      iteration: 0,
+      pagesProcessed: 0,
+      currentPageFingerprint: null,
+      previousPageFingerprint: null,
+      samePageCount: 0,
+      actionHistory: [],
+      loopCostUsd: 0,
+      terminalState: 'running',
+      terminationReason: null,
+    });
+
+    try {
+      while (loopState.terminalState === 'running') {
+        loopState.iteration += 1;
+        loopState.pagesProcessed += 1;
+        this.emit({
+          type: 'observe',
+          iteration: loopState.iteration,
+          message: 'Building page snapshot.',
+        });
+
+        const snapshot = await this.snapshotBuilder.buildSnapshot(this.page, loopState.actionHistory);
+        loopState.previousPageFingerprint = loopState.currentPageFingerprint;
+        loopState.currentPageFingerprint = snapshot.fingerprint.hash;
+        loopState.samePageCount =
+          loopState.previousPageFingerprint &&
+          loopState.previousPageFingerprint === loopState.currentPageFingerprint
+            ? loopState.samePageCount + 1
+            : 0;
+
+        this.emit({
+          type: 'decide',
+          iteration: loopState.iteration,
+          message: `Deciding next action for ${snapshot.pageType} page.`,
+        });
+
+        const decisionResult = await this.decisionEngine.decide(
+          snapshot,
+          this.profileSummary,
+          this.platform,
+        );
+        loopState.loopCostUsd += decisionResult.costUsd;
+
+        const guardedDecision = this.applyGuardrails(decisionResult, snapshot);
+        this.emit({
+          type: 'decision',
+          iteration: loopState.iteration,
+          message: `Decision: ${guardedDecision.action}${guardedDecision.target ? ` (${guardedDecision.target})` : ''}`,
+        });
+
+        const executorResult = await this.actionExecutor.execute(guardedDecision, snapshot);
+        loopState.loopCostUsd += executorResult.costUsd;
+
+        const historyEntry: ActionHistoryEntry = {
+          iteration: loopState.iteration,
+          action: guardedDecision.action,
+          target: guardedDecision.target || '',
+          result: deriveActionResult(guardedDecision, executorResult),
+          layer: executorResult.layer,
+          costUsd: decisionResult.costUsd + executorResult.costUsd,
+          durationMs: decisionResult.durationMs + executorResult.durationMs,
+          fieldsAttempted: executorResult.fieldsAttempted,
+          fieldsFilled: executorResult.fieldsFilled,
+          pageFingerprint: snapshot.fingerprint.hash,
+          timestamp: Date.now(),
+        };
+        loopState.actionHistory = [...loopState.actionHistory, historyEntry].slice(-ACTION_HISTORY_LIMIT);
+
+        const configuredMaxIterationReached = loopState.iteration >= this.maxIterations;
+        const termination = configuredMaxIterationReached
+          ? {
+            type: 'max_iterations' as const,
+            reason: `Reached configured max iteration limit (${this.maxIterations}).`,
+          }
+          : checkTermination(guardedDecision, loopState, this.budgetUsd);
+
+        this.emit({
+          type: 'action',
+          iteration: loopState.iteration,
+          message: executorResult.summary,
+        });
+
+        if (termination) {
+          if (termination.type === 'blocked') {
+            loopState.terminalState = 'error';
+            loopState.terminationReason = termination.reason;
+            break;
+          }
+
+          loopState.terminalState = termination.type;
+          loopState.terminationReason = termination.reason;
+          this.emit({
+            type: 'termination',
+            iteration: loopState.iteration,
+            message: termination.reason,
+          });
+          break;
+        }
+
+        if (executorResult.pageNavigated) {
+          await this.page.waitForLoadState('domcontentloaded', { timeout: 2000 }).catch(() => {});
+          await sleep(2000);
+        }
+      }
+    } catch (error) {
+      loopState.terminalState = 'error';
+      loopState.terminationReason = error instanceof Error ? error.message : String(error);
+      this.emit({
+        type: 'error',
+        iteration: loopState.iteration,
+        message: loopState.terminationReason,
+      });
+    }
+
+    const terminalState = loopState.terminalState;
+    const terminationReason = loopState.terminationReason || 'Decision loop exited without a termination reason.';
+    return {
+      success: terminalState === 'confirmation' || terminalState === 'review_page' || terminalState === 'submitted',
+      terminalState,
+      terminationReason,
+      loopState: DecisionLoopStateSchema.parse(loopState),
+    };
+  }
+
+  private emit(event: ProgressEvent): void {
+    this.onProgress?.(event);
+  }
+
+  private applyGuardrails(
+    decision: DecisionAction,
+    snapshot: Awaited<ReturnType<PageSnapshotBuilder['buildSnapshot']>>,
+  ): DecisionAction {
+    if (snapshot.blocker.detected && snapshot.blocker.type === 'captcha') {
+      return {
+        action: 'report_blocked',
+        reasoning: `${decision.reasoning} Guardrail override: CAPTCHA or human-verification challenge detected.`,
+        confidence: Math.max(decision.confidence, snapshot.blocker.confidence),
+      };
+    }
+
+    if (snapshot.pageType === 'confirmation') {
+      return {
+        action: 'mark_complete',
+        reasoning: `${decision.reasoning} Guardrail override: confirmation page detected.`,
+        confidence: Math.max(decision.confidence, 0.95),
+      };
+    }
+
+    const emptyVisibleFields = snapshot.fields.filter(
+      (field) => field.isVisible && !field.isDisabled && field.isEmpty,
+    );
+    const looksLikeReviewPage =
+      /review/i.test(snapshot.pageType) ||
+      (
+        emptyVisibleFields.length === 0 &&
+        snapshot.buttons.some((button) => /submit/i.test(button.text))
+      );
+
+    if (looksLikeReviewPage && decision.action !== 'stop_for_review' && decision.action !== 'mark_complete') {
+      return {
+        action: 'stop_for_review',
+        reasoning: `${decision.reasoning} Guardrail override: review-like page detected; do not click submit.`,
+        confidence: Math.max(decision.confidence, 0.9),
+      };
+    }
+
+    if (
+      (decision.action === 'click_next' || decision.action === 'click_apply') &&
+      emptyVisibleFields.length > 0 &&
+      !/login|verification|account/.test(snapshot.pageType)
+    ) {
+      return {
+        action: 'fill_form',
+        reasoning: `${decision.reasoning} Guardrail override: editable empty fields remain visible, so filling is safer than navigating.`,
+        confidence: Math.max(decision.confidence, 0.85),
+        fieldsToFill: emptyVisibleFields.slice(0, 15).map((field) => field.label),
+      };
+    }
+
+    if (decision.action === 'click_apply') {
+      const targetText = normalizeText(decision.target);
+      const dangerousButton = snapshot.buttons.find((button) =>
+        /submit|finish|send application/i.test(button.text) &&
+        (!targetText ||
+          normalizeText(button.text).includes(targetText) ||
+          normalizeText(button.selector).includes(targetText)),
+      );
+      if (dangerousButton) {
+        return {
+          action: 'stop_for_review',
+          reasoning: `${decision.reasoning} Guardrail override: resolved apply target appears to be a final submission button.`,
+          confidence: Math.max(decision.confidence, 0.95),
+        };
+      }
+    }
+
+    return decision;
+  }
+}

--- a/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
+++ b/packages/ghosthands/src/engine/decision/DecisionLoopRunner.ts
@@ -126,6 +126,8 @@ export class DecisionLoopRunner {
   private readonly decisionEngine: PageDecisionEngine;
   private readonly actionExecutor: ActionExecutor;
   private readonly profileSummary: string;
+  private readonly previousActionHistory: ActionHistoryEntry[];
+  private readonly previousIteration: number;
 
   constructor(config: {
     page: Page;
@@ -137,6 +139,8 @@ export class DecisionLoopRunner {
     model?: string;
     onProgress?: (event: { type: string; message: string; iteration: number }) => void;
     maxIterations?: number;
+    previousActionHistory?: ActionHistoryEntry[];
+    previousIteration?: number;
   }) {
     this.page = config.page;
     this.adapter = config.adapter;
@@ -152,30 +156,30 @@ export class DecisionLoopRunner {
     });
     this.actionExecutor = new ActionExecutor(config.page, config.adapter);
     this.profileSummary = summarizeProfile(config.profile);
+    this.previousActionHistory = config.previousActionHistory ?? [];
+    this.previousIteration = config.previousIteration ?? 0;
   }
 
-  async run(): Promise<{
-    success: boolean;
-    terminalState: string;
-    terminationReason: string;
-    loopState: DecisionLoopState;
+  async run(): Promise<DecisionLoopState & {
+    blockerDetected?: { type: string; confidence: number; pageUrl: string };
   }> {
     const loopState: DecisionLoopState = DecisionLoopStateSchema.parse({
-      iteration: 0,
+      iteration: this.previousIteration,
       pagesProcessed: 0,
       currentPageFingerprint: null,
       previousPageFingerprint: null,
       samePageCount: 0,
-      actionHistory: [],
+      actionHistory: this.previousActionHistory.slice(-ACTION_HISTORY_LIMIT),
       loopCostUsd: 0,
       terminalState: 'running',
       terminationReason: null,
     });
 
+    let blockerDetected: { type: string; confidence: number; pageUrl: string } | undefined;
+
     try {
       while (loopState.terminalState === 'running') {
         loopState.iteration += 1;
-        loopState.pagesProcessed += 1;
         this.emit({
           type: 'observe',
           iteration: loopState.iteration,
@@ -185,11 +189,13 @@ export class DecisionLoopRunner {
         const snapshot = await this.snapshotBuilder.buildSnapshot(this.page, loopState.actionHistory);
         loopState.previousPageFingerprint = loopState.currentPageFingerprint;
         loopState.currentPageFingerprint = snapshot.fingerprint.hash;
-        loopState.samePageCount =
-          loopState.previousPageFingerprint &&
-          loopState.previousPageFingerprint === loopState.currentPageFingerprint
-            ? loopState.samePageCount + 1
-            : 0;
+        const pageChanged = loopState.previousPageFingerprint !== loopState.currentPageFingerprint;
+        if (pageChanged || !loopState.previousPageFingerprint) {
+          loopState.pagesProcessed += 1;
+        }
+        loopState.samePageCount = !pageChanged && loopState.previousPageFingerprint
+          ? loopState.samePageCount + 1
+          : 0;
 
         this.emit({
           type: 'decide',
@@ -244,14 +250,15 @@ export class DecisionLoopRunner {
         });
 
         if (termination) {
-          if (termination.type === 'blocked') {
-            loopState.terminalState = 'error';
-            loopState.terminationReason = termination.reason;
-            break;
-          }
-
           loopState.terminalState = termination.type;
           loopState.terminationReason = termination.reason;
+          if (termination.type === 'blocked') {
+            blockerDetected = {
+              type: snapshot.blocker.type ?? 'unknown',
+              confidence: snapshot.blocker.confidence,
+              pageUrl: snapshot.url,
+            };
+          }
           this.emit({
             type: 'termination',
             iteration: loopState.iteration,
@@ -275,13 +282,10 @@ export class DecisionLoopRunner {
       });
     }
 
-    const terminalState = loopState.terminalState;
-    const terminationReason = loopState.terminationReason || 'Decision loop exited without a termination reason.';
+    loopState.terminationReason = loopState.terminationReason || 'Decision loop exited without a termination reason.';
     return {
-      success: terminalState === 'confirmation' || terminalState === 'review_page' || terminalState === 'submitted',
-      terminalState,
-      terminationReason,
-      loopState: DecisionLoopStateSchema.parse(loopState),
+      ...DecisionLoopStateSchema.parse(loopState),
+      ...(blockerDetected ? { blockerDetected } : {}),
     };
   }
 

--- a/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
+++ b/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
@@ -1,0 +1,144 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { ToolUseBlock } from '@anthropic-ai/sdk/resources/messages';
+import type { AnthropicClientConfig } from '../../workers/taskHandlers/types';
+import {
+  buildSystemPrompt,
+  buildUserMessage,
+  DECISION_TOOL,
+  PLATFORM_GUARDRAILS,
+} from './prompts';
+import type { DecisionAction, PageDecisionContext } from './types';
+import { DecisionActionSchema } from './types';
+
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+
+function normalizeModel(raw?: string): string {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_MODEL;
+  return trimmed.replace('@', '-');
+}
+
+function buildAnthropicClientOptions(config?: AnthropicClientConfig): ConstructorParameters<typeof Anthropic>[0] | undefined {
+  if (!config) return undefined;
+
+  const { apiKey, authToken, baseURL, defaultHeaders } = config;
+  const options = {
+    ...(apiKey ? { apiKey } : {}),
+    ...(authToken ? { authToken } : {}),
+    ...(baseURL ? { baseURL } : {}),
+    ...(defaultHeaders && Object.keys(defaultHeaders).length > 0 ? { defaultHeaders } : {}),
+  };
+
+  return Object.keys(options).length > 0 ? options : undefined;
+}
+
+function estimateAnthropicCostUsd(model: string, inputTokens: number, outputTokens: number): number {
+  const normalized = normalizeModel(model).toLowerCase();
+
+  if (normalized.includes('haiku')) {
+    return (inputTokens * 1.0 + outputTokens * 5.0) / 1_000_000;
+  }
+
+  if (normalized.includes('sonnet')) {
+    return (inputTokens * 3.0 + outputTokens * 15.0) / 1_000_000;
+  }
+
+  return 0;
+}
+
+export class PageDecisionEngine {
+  private readonly client: Anthropic;
+  private readonly model: string;
+
+  constructor(config: { anthropicConfig?: AnthropicClientConfig; model?: string } = {}) {
+    this.client = new Anthropic(buildAnthropicClientOptions(config.anthropicConfig));
+    this.model = normalizeModel(config.model);
+  }
+
+  async decide(
+    context: PageDecisionContext,
+    profileSummary: string,
+    platform: string,
+  ): Promise<DecisionAction & {
+    tokenUsage: { input: number; output: number };
+    costUsd: number;
+    durationMs: number;
+  }> {
+    const startedAt = Date.now();
+    const system = buildSystemPrompt(
+      profileSummary,
+      PLATFORM_GUARDRAILS[platform] ?? PLATFORM_GUARDRAILS.other,
+    );
+    const userMessage = buildUserMessage(context);
+
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 512,
+      temperature: 0,
+      system,
+      tools: [DECISION_TOOL],
+      tool_choice: {
+        type: 'tool',
+        name: DECISION_TOOL.name,
+      },
+      messages: [
+        {
+          role: 'user',
+          content: userMessage,
+        },
+      ],
+    });
+
+    const inputTokens = response.usage?.input_tokens ?? 0;
+    const outputTokens = response.usage?.output_tokens ?? 0;
+    const durationMs = Date.now() - startedAt;
+    const costUsd = estimateAnthropicCostUsd(this.model, inputTokens, outputTokens);
+
+    const toolUse = response.content.find(
+      (block): block is ToolUseBlock =>
+        block.type === 'tool_use' && block.name === DECISION_TOOL.name,
+    );
+
+    if (!toolUse) {
+      return {
+        action: 'wait_and_retry',
+        reasoning: 'Decision model returned no page_decision tool payload; retrying conservatively.',
+        confidence: 0.15,
+        tokenUsage: {
+          input: inputTokens,
+          output: outputTokens,
+        },
+        costUsd,
+        durationMs,
+      };
+    }
+
+    const parsed = DecisionActionSchema.safeParse(toolUse.input);
+    if (!parsed.success) {
+      return {
+        action: 'wait_and_retry',
+        reasoning: 'Decision payload failed schema validation; retrying conservatively.',
+        confidence: 0.1,
+        target: typeof toolUse.input === 'object' && toolUse.input && 'target' in toolUse.input
+          ? String((toolUse.input as Record<string, unknown>).target ?? '')
+          : undefined,
+        tokenUsage: {
+          input: inputTokens,
+          output: outputTokens,
+        },
+        costUsd,
+        durationMs,
+      };
+    }
+
+    return {
+      ...parsed.data,
+      tokenUsage: {
+        input: inputTokens,
+        output: outputTokens,
+      },
+      costUsd,
+      durationMs,
+    };
+  }
+}

--- a/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
+++ b/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
@@ -35,27 +35,30 @@ function buildAnthropicClientOptions(config?: AnthropicClientConfig): Constructo
   return Object.keys(options).length > 0 ? options : undefined;
 }
 
-function estimateAnthropicCostUsd(model: string, inputTokens: number, outputTokens: number): number {
-  const normalized = normalizeModel(model).toLowerCase();
-
-  if (normalized.includes('haiku')) {
-    return (inputTokens * 0.25 + outputTokens * 1.25) / 1_000_000;
-  }
-
-  if (normalized.includes('sonnet')) {
-    return (inputTokens * 3.0 + outputTokens * 15.0) / 1_000_000;
-  }
-
-  return 0;
-}
+/**
+ * Cost callback type — allows the caller to report token usage
+ * to the CostTracker (which uses real costs from adapter events)
+ * rather than estimating locally with hardcoded rates.
+ */
+export type OnTokenUsage = (usage: {
+  inputTokens: number;
+  outputTokens: number;
+  model: string;
+}) => void;
 
 export class PageDecisionEngine {
   private readonly client: Anthropic;
   private readonly model: string;
+  private readonly onTokenUsage?: OnTokenUsage;
 
-  constructor(config: { anthropicConfig?: AnthropicClientConfig; model?: string } = {}) {
+  constructor(config: {
+    anthropicConfig?: AnthropicClientConfig;
+    model?: string;
+    onTokenUsage?: OnTokenUsage;
+  } = {}) {
     this.client = new Anthropic(buildAnthropicClientOptions(config.anthropicConfig));
     this.model = normalizeModel(config.model);
+    this.onTokenUsage = config.onTokenUsage;
   }
 
   async decide(
@@ -64,7 +67,6 @@ export class PageDecisionEngine {
     platform: string,
   ): Promise<DecisionAction & {
     tokenUsage: { input: number; output: number };
-    costUsd: number;
     durationMs: number;
   }> {
     const startedAt = Date.now();
@@ -130,7 +132,6 @@ export class PageDecisionEngine {
         reasoning: `Anthropic API call failed after ${MAX_API_RETRIES + 1} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
         confidence: 0.05,
         tokenUsage: { input: 0, output: 0 },
-        costUsd: 0,
         durationMs,
       };
     }
@@ -138,7 +139,12 @@ export class PageDecisionEngine {
     const inputTokens = response.usage?.input_tokens ?? 0;
     const outputTokens = response.usage?.output_tokens ?? 0;
     const durationMs = Date.now() - startedAt;
-    const costUsd = estimateAnthropicCostUsd(this.model, inputTokens, outputTokens);
+
+    // Report token usage to CostTracker via callback instead of estimating locally.
+    // The CostTracker receives real cost data from adapter tokensUsed events for
+    // adapter calls. For direct Anthropic calls (decision engine), the CostTracker
+    // uses the token counts for tracking; actual billing goes through VALET proxy.
+    this.onTokenUsage?.({ inputTokens, outputTokens, model: this.model });
 
     const toolUse = response.content.find(
       (block): block is ToolUseBlock =>
@@ -154,7 +160,6 @@ export class PageDecisionEngine {
           input: inputTokens,
           output: outputTokens,
         },
-        costUsd,
         durationMs,
       };
     }
@@ -172,7 +177,6 @@ export class PageDecisionEngine {
           input: inputTokens,
           output: outputTokens,
         },
-        costUsd,
         durationMs,
       };
     }
@@ -183,7 +187,6 @@ export class PageDecisionEngine {
         input: inputTokens,
         output: outputTokens,
       },
-      costUsd,
       durationMs,
     };
   }

--- a/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
+++ b/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
@@ -11,6 +11,9 @@ import type { DecisionAction, PageDecisionContext } from './types';
 import { DecisionActionSchema } from './types';
 
 const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+const MAX_API_RETRIES = 2;
+const API_TIMEOUT_MS = 30_000;
+const RETRY_BACKOFF_BASE_MS = 1000;
 
 function normalizeModel(raw?: string): string {
   const trimmed = raw?.trim();
@@ -71,23 +74,64 @@ export class PageDecisionEngine {
     );
     const userMessage = buildUserMessage(context);
 
-    const response = await this.client.messages.create({
-      model: this.model,
-      max_tokens: 512,
-      temperature: 0,
-      system,
-      tools: [DECISION_TOOL],
-      tool_choice: {
-        type: 'tool',
-        name: DECISION_TOOL.name,
-      },
-      messages: [
-        {
-          role: 'user',
-          content: userMessage,
-        },
-      ],
-    });
+    let response!: Anthropic.Messages.Message;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= MAX_API_RETRIES; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+
+        response = await this.client.messages.create(
+          {
+            model: this.model,
+            max_tokens: 512,
+            temperature: 0,
+            system,
+            tools: [DECISION_TOOL],
+            tool_choice: {
+              type: 'tool',
+              name: DECISION_TOOL.name,
+            },
+            messages: [
+              {
+                role: 'user',
+                content: userMessage,
+              },
+            ],
+          },
+          { signal: controller.signal },
+        );
+
+        clearTimeout(timeout);
+        lastError = null;
+        break;
+      } catch (err) {
+        lastError = err;
+        const isRateLimit = err instanceof Anthropic.RateLimitError;
+        const isTimeout = err instanceof Error && err.name === 'AbortError';
+        const isServerError = err instanceof Anthropic.InternalServerError;
+
+        if (attempt < MAX_API_RETRIES && (isRateLimit || isTimeout || isServerError)) {
+          const backoff = RETRY_BACKOFF_BASE_MS * Math.pow(2, attempt);
+          await new Promise((r) => setTimeout(r, backoff));
+          continue;
+        }
+        break;
+      }
+    }
+
+    if (lastError) {
+      const durationMs = Date.now() - startedAt;
+      return {
+        action: 'wait_and_retry',
+        reasoning: `Anthropic API call failed after ${MAX_API_RETRIES + 1} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+        confidence: 0.05,
+        tokenUsage: { input: 0, output: 0 },
+        costUsd: 0,
+        durationMs,
+      };
+    }
 
     const inputTokens = response.usage?.input_tokens ?? 0;
     const outputTokens = response.usage?.output_tokens ?? 0;

--- a/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
+++ b/packages/ghosthands/src/engine/decision/PageDecisionEngine.ts
@@ -39,7 +39,7 @@ function estimateAnthropicCostUsd(model: string, inputTokens: number, outputToke
   const normalized = normalizeModel(model).toLowerCase();
 
   if (normalized.includes('haiku')) {
-    return (inputTokens * 1.0 + outputTokens * 5.0) / 1_000_000;
+    return (inputTokens * 0.25 + outputTokens * 1.25) / 1_000_000;
   }
 
   if (normalized.includes('sonnet')) {
@@ -78,9 +78,10 @@ export class PageDecisionEngine {
     let lastError: unknown;
 
     for (let attempt = 0; attempt <= MAX_API_RETRIES; attempt++) {
+      let timeout: ReturnType<typeof setTimeout> | undefined;
       try {
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+        timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
 
         response = await this.client.messages.create(
           {
@@ -107,6 +108,7 @@ export class PageDecisionEngine {
         lastError = null;
         break;
       } catch (err) {
+        clearTimeout(timeout);
         lastError = err;
         const isRateLimit = err instanceof Anthropic.RateLimitError;
         const isTimeout = err instanceof Error && err.name === 'AbortError';

--- a/packages/ghosthands/src/engine/decision/actionExecutor.ts
+++ b/packages/ghosthands/src/engine/decision/actionExecutor.ts
@@ -84,15 +84,46 @@ export class ActionExecutor {
         };
         break;
       case 'upload_resume':
-        result = {
-          ok: true,
-          layer: null,
-          fieldsAttempted: 0,
-          fieldsFilled: 0,
-          costUsd: 0,
-          pageNavigated: false,
-          summary: 'Resume upload deferred to external file chooser handling.',
-        };
+        // Resume upload is handled externally via Playwright filechooser event
+        // (set up in JobExecutor). We click the file input to trigger the chooser.
+        try {
+          const fileInput = await this.page.$('input[type="file"]');
+          if (fileInput) {
+            await fileInput.click({ timeout: 3000 });
+            await sleep(1500); // Allow filechooser event to fire
+            result = {
+              ok: true,
+              layer: 'dom',
+              fieldsAttempted: 1,
+              fieldsFilled: 1,
+              costUsd: 0,
+              pageNavigated: false,
+              summary: 'Clicked file input to trigger resume upload via filechooser handler.',
+            };
+          } else {
+            result = {
+              ok: false,
+              layer: 'dom',
+              fieldsAttempted: 1,
+              fieldsFilled: 0,
+              costUsd: 0,
+              pageNavigated: false,
+              summary: 'No file input found on page; resume upload may require Stagehand/Magnitude.',
+              error: 'no_file_input',
+            };
+          }
+        } catch (error) {
+          result = {
+            ok: false,
+            layer: 'dom',
+            fieldsAttempted: 1,
+            fieldsFilled: 0,
+            costUsd: 0,
+            pageNavigated: false,
+            summary: 'File input click failed.',
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
         break;
       case 'login':
         result = await this.executeAdapterAuthAction(
@@ -221,6 +252,40 @@ export class ActionExecutor {
       };
     }
 
+    // When the LLM provides fieldValues, attempt direct DOM fill
+    const fieldValues = action.fieldValues;
+    if (fieldValues && Object.keys(fieldValues).length > 0) {
+      let filled = 0;
+      for (const field of emptyTargets) {
+        const fieldLabel = normalizeText(field.label);
+        const matchingKey = Object.keys(fieldValues).find((key) => {
+          const normalizedKey = normalizeText(key);
+          return normalizedKey === fieldLabel || fieldLabel.includes(normalizedKey) || normalizedKey.includes(fieldLabel);
+        });
+        if (!matchingKey) continue;
+
+        try {
+          await this.page.locator(field.selector).first().fill(fieldValues[matchingKey], { timeout: 3000 });
+          filled++;
+        } catch {
+          // Individual field failure is not fatal; continue with remaining fields
+        }
+      }
+
+      if (filled > 0) {
+        return {
+          ok: true,
+          layer: 'dom',
+          fieldsAttempted: emptyTargets.length,
+          fieldsFilled: filled,
+          costUsd: 0,
+          pageNavigated: false,
+          summary: `DOM-filled ${filled} of ${emptyTargets.length} fields using LLM-provided values.`,
+        };
+      }
+    }
+
+    // No fieldValues provided or none matched — escalate to next tier
     return {
       ok: false,
       layer: 'dom',
@@ -228,8 +293,8 @@ export class ActionExecutor {
       fieldsFilled: 0,
       costUsd: 0,
       pageNavigated: false,
-      summary: 'DOM fill skipped because decision actions do not yet include concrete field values.',
-      error: 'missing_field_values',
+      summary: 'DOM fill could not resolve concrete values for target fields; escalating to Stagehand.',
+      error: 'no_field_values_matched',
     };
   }
 
@@ -510,12 +575,21 @@ export class ActionExecutor {
     let clicked = 0;
     const beforeUrl = this.safePageUrl();
     for (const repeater of repeaters) {
-      try {
-        await this.page.locator(repeater.addButtonSelector).first().click({ timeout: 3000 });
-        clicked++;
-        await this.page.waitForTimeout(250);
-      } catch {
-        // Keep going so one bad repeater does not hide the rest.
+      // Determine how many clicks needed: targetCount - currentCount, minimum 1
+      const clicksNeeded = repeater.targetCount && repeater.targetCount > repeater.currentCount
+        ? repeater.targetCount - repeater.currentCount
+        : 1;
+
+      for (let i = 0; i < clicksNeeded; i++) {
+        try {
+          await this.page.locator(repeater.addButtonSelector).first().click({ timeout: 3000 });
+          clicked++;
+          // Wait for DOM to settle between expansion clicks
+          await this.page.waitForTimeout(500);
+        } catch {
+          // Stop clicking this repeater if a click fails
+          break;
+        }
       }
     }
 

--- a/packages/ghosthands/src/engine/decision/actionExecutor.ts
+++ b/packages/ghosthands/src/engine/decision/actionExecutor.ts
@@ -8,8 +8,10 @@ import type {
 } from './types';
 import { ExecutorResultSchema } from './types';
 
-const ESTIMATED_STAGEHAND_COST_USD = 0.0005;
-const ESTIMATED_MAGNITUDE_COST_USD = 0.005;
+// Cost tracking is handled by the CostTracker via adapter tokensUsed events.
+// Adapter calls (act/observe) emit tokensUsed with real inputCost/outputCost
+// from the LLM provider, which the JobExecutor listener routes to CostTracker.
+// No local cost estimation is needed here.
 
 type ExecutionAttempt = {
   ok: boolean;
@@ -336,7 +338,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length,
         fieldsFilled: result.success ? (fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length) : 0,
-        costUsd: ESTIMATED_STAGEHAND_COST_USD,
+        costUsd: 0,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Stagehand fill attempt completed.',
         error: result.success ? undefined : result.message,
@@ -347,7 +349,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: this.resolveTargetFields(action, context).length,
         fieldsFilled: 0,
-        costUsd: ESTIMATED_STAGEHAND_COST_USD,
+        costUsd: 0,
         pageNavigated: false,
         summary: 'Stagehand fill attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -378,7 +380,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length,
         fieldsFilled: result.success ? (fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length) : 0,
-        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
+        costUsd: 0,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Magnitude fill attempt completed.',
         error: result.success ? undefined : result.message,
@@ -389,7 +391,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: this.resolveTargetFields(action, context).length,
         fieldsFilled: 0,
-        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
+        costUsd: 0,
         pageNavigated: false,
         summary: 'Magnitude fill attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -468,7 +470,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: ESTIMATED_STAGEHAND_COST_USD,
+        costUsd: 0,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Stagehand click attempt completed.',
         error: result.success ? undefined : result.message,
@@ -479,7 +481,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: ESTIMATED_STAGEHAND_COST_USD,
+        costUsd: 0,
         pageNavigated: false,
         summary: 'Stagehand click attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -504,7 +506,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
+        costUsd: 0,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Magnitude click attempt completed.',
         error: result.success ? undefined : result.message,
@@ -515,7 +517,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
+        costUsd: 0,
         pageNavigated: false,
         summary: 'Magnitude click attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -525,7 +527,6 @@ export class ActionExecutor {
 
   private async executeAdapterAuthAction(instruction: string): Promise<ExecutionAttempt> {
     const layer: ExecutorResult['layer'] = this.adapter.observe ? 'stagehand' : 'magnitude';
-    const estimatedCost = layer === 'stagehand' ? ESTIMATED_STAGEHAND_COST_USD : ESTIMATED_MAGNITUDE_COST_USD;
     try {
       const beforeUrl = this.safePageUrl();
       const result = await this.adapter.act(instruction);
@@ -534,7 +535,7 @@ export class ActionExecutor {
         layer,
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: estimatedCost,
+        costUsd: 0,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Adapter auth action completed.',
         error: result.success ? undefined : result.message,
@@ -546,7 +547,7 @@ export class ActionExecutor {
         layer,
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: estimatedCost,
+        costUsd: 0,
         pageNavigated: false,
         summary: 'Adapter auth action failed.',
         error: error instanceof Error ? error.message : String(error),

--- a/packages/ghosthands/src/engine/decision/actionExecutor.ts
+++ b/packages/ghosthands/src/engine/decision/actionExecutor.ts
@@ -8,6 +8,9 @@ import type {
 } from './types';
 import { ExecutorResultSchema } from './types';
 
+const ESTIMATED_STAGEHAND_COST_USD = 0.0005;
+const ESTIMATED_MAGNITUDE_COST_USD = 0.005;
+
 type ExecutionAttempt = {
   ok: boolean;
   layer: ExecutorResult['layer'];
@@ -333,7 +336,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length,
         fieldsFilled: result.success ? (fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length) : 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_STAGEHAND_COST_USD,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Stagehand fill attempt completed.',
         error: result.success ? undefined : result.message,
@@ -344,7 +347,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: this.resolveTargetFields(action, context).length,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_STAGEHAND_COST_USD,
         pageNavigated: false,
         summary: 'Stagehand fill attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -375,7 +378,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length,
         fieldsFilled: result.success ? (fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length) : 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Magnitude fill attempt completed.',
         error: result.success ? undefined : result.message,
@@ -386,7 +389,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: this.resolveTargetFields(action, context).length,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
         pageNavigated: false,
         summary: 'Magnitude fill attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -465,7 +468,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_STAGEHAND_COST_USD,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Stagehand click attempt completed.',
         error: result.success ? undefined : result.message,
@@ -476,7 +479,7 @@ export class ActionExecutor {
         layer: 'stagehand',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_STAGEHAND_COST_USD,
         pageNavigated: false,
         summary: 'Stagehand click attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -501,7 +504,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Magnitude click attempt completed.',
         error: result.success ? undefined : result.message,
@@ -512,7 +515,7 @@ export class ActionExecutor {
         layer: 'magnitude',
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: ESTIMATED_MAGNITUDE_COST_USD,
         pageNavigated: false,
         summary: 'Magnitude click attempt failed.',
         error: error instanceof Error ? error.message : String(error),
@@ -521,15 +524,17 @@ export class ActionExecutor {
   }
 
   private async executeAdapterAuthAction(instruction: string): Promise<ExecutionAttempt> {
+    const layer: ExecutorResult['layer'] = this.adapter.observe ? 'stagehand' : 'magnitude';
+    const estimatedCost = layer === 'stagehand' ? ESTIMATED_STAGEHAND_COST_USD : ESTIMATED_MAGNITUDE_COST_USD;
     try {
       const beforeUrl = this.safePageUrl();
       const result = await this.adapter.act(instruction);
       return {
         ok: result.success,
-        layer: this.adapter.observe ? 'stagehand' : 'magnitude',
+        layer,
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: estimatedCost,
         pageNavigated: beforeUrl !== this.safePageUrl(),
         summary: result.message || 'Adapter auth action completed.',
         error: result.success ? undefined : result.message,
@@ -538,10 +543,10 @@ export class ActionExecutor {
     } catch (error) {
       return {
         ok: false,
-        layer: this.adapter.observe ? 'stagehand' : 'magnitude',
+        layer,
         fieldsAttempted: 0,
         fieldsFilled: 0,
-        costUsd: 0,
+        costUsd: estimatedCost,
         pageNavigated: false,
         summary: 'Adapter auth action failed.',
         error: error instanceof Error ? error.message : String(error),

--- a/packages/ghosthands/src/engine/decision/actionExecutor.ts
+++ b/packages/ghosthands/src/engine/decision/actionExecutor.ts
@@ -1,0 +1,616 @@
+import type { BrowserAutomationAdapter } from '../../adapters/types';
+import type { Page } from 'playwright';
+import type {
+  DecisionAction,
+  ExecutorResult,
+  FieldSnapshot,
+  PageDecisionContext,
+} from './types';
+import { ExecutorResultSchema } from './types';
+
+type ExecutionAttempt = {
+  ok: boolean;
+  layer: ExecutorResult['layer'];
+  fieldsAttempted: number;
+  fieldsFilled: number;
+  pageNavigated: boolean;
+  costUsd: number;
+  summary: string;
+  error?: string;
+  terminal?: boolean;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeText(value: string | undefined | null): string {
+  return (value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function looksLikeSelector(value: string): boolean {
+  return /^[#.[]/.test(value) || value.includes('data-') || value.includes('button') || value.includes('input');
+}
+
+export class ActionExecutor {
+  constructor(
+    private readonly page: Page,
+    private readonly adapter: BrowserAutomationAdapter,
+  ) {}
+
+  async execute(action: DecisionAction, context: PageDecisionContext): Promise<ExecutorResult> {
+    const startedAt = Date.now();
+    let result: ExecutionAttempt;
+
+    switch (action.action) {
+      case 'fill_form':
+        result = await this.executeFill(action, context);
+        break;
+      case 'click_next':
+      case 'click_apply':
+      case 'dismiss_popup':
+        result = await this.executeClick(action, context);
+        break;
+      case 'select_option':
+        result = await this.tryMagnitudeFill(action, context);
+        break;
+      case 'scroll_down': {
+        const beforeUrl = this.safePageUrl();
+        await this.page.evaluate(() => {
+          window.scrollBy(0, Math.max(Math.floor(window.innerHeight * 0.8), 400));
+        });
+        await this.page.waitForTimeout(250);
+        result = {
+          ok: true,
+          layer: null,
+          fieldsAttempted: 0,
+          fieldsFilled: 0,
+          costUsd: 0,
+          pageNavigated: beforeUrl !== this.safePageUrl(),
+          summary: 'Scrolled down to reveal more page content.',
+        };
+        break;
+      }
+      case 'wait_and_retry':
+        await sleep(2000);
+        result = {
+          ok: true,
+          layer: null,
+          fieldsAttempted: 0,
+          fieldsFilled: 0,
+          costUsd: 0,
+          pageNavigated: false,
+          summary: 'Paused briefly before the next observation cycle.',
+        };
+        break;
+      case 'upload_resume':
+        result = {
+          ok: true,
+          layer: null,
+          fieldsAttempted: 0,
+          fieldsFilled: 0,
+          costUsd: 0,
+          pageNavigated: false,
+          summary: 'Resume upload deferred to external file chooser handling.',
+        };
+        break;
+      case 'login':
+        result = await this.executeAdapterAuthAction(
+          'Sign in using already-registered credentials available in your runtime context. Do not submit the final application.',
+        );
+        break;
+      case 'create_account':
+        result = await this.executeAdapterAuthAction(
+          'Create an account using available applicant data and runtime credentials context. Do not submit the final application.',
+        );
+        break;
+      case 'enter_verification':
+        result = await this.executeAdapterAuthAction(
+          'Enter the required verification code or complete the verification step using trusted runtime context. If no trusted code is available, stop without risky guesses.',
+        );
+        break;
+      case 'expand_repeaters':
+        result = await this.expandRepeaters(action, context);
+        break;
+      case 'stop_for_review':
+      case 'mark_complete':
+      case 'report_blocked':
+        result = {
+          ok: true,
+          layer: null,
+          fieldsAttempted: 0,
+          fieldsFilled: 0,
+          costUsd: 0,
+          pageNavigated: false,
+          summary: `No browser action executed for terminal decision "${action.action}".`,
+        };
+        break;
+      default:
+        result = {
+          ok: false,
+          layer: null,
+          fieldsAttempted: 0,
+          fieldsFilled: 0,
+          costUsd: 0,
+          pageNavigated: false,
+          summary: `Unsupported action "${action.action}".`,
+          error: `Unsupported action "${action.action}"`,
+          terminal: true,
+        };
+        break;
+    }
+
+    const status: ExecutorResult['status'] =
+      action.action === 'stop_for_review' ||
+      action.action === 'mark_complete' ||
+      action.action === 'report_blocked'
+        ? 'needs_review'
+        : result.ok
+          ? 'action_succeeded'
+          : result.terminal
+            ? 'action_failed_terminal'
+            : 'action_failed_retryable';
+
+    return ExecutorResultSchema.parse({
+      status,
+      layer: result.layer,
+      fieldsAttempted: result.fieldsAttempted,
+      fieldsFilled: result.fieldsFilled,
+      durationMs: Date.now() - startedAt,
+      costUsd: result.costUsd,
+      pageNavigated: result.pageNavigated,
+      error: result.error,
+      summary: result.summary,
+    });
+  }
+
+  private async executeFill(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): Promise<ExecutionAttempt> {
+    const domAttempt = await this.tryDOMFill(action, context);
+    if (domAttempt.ok) return domAttempt;
+
+    const stagehandAttempt = await this.tryStagehandFill(action, context);
+    if (stagehandAttempt.ok) return stagehandAttempt;
+
+    return this.tryMagnitudeFill(action, context, domAttempt.error || stagehandAttempt.error);
+  }
+
+  private async executeClick(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): Promise<ExecutionAttempt> {
+    const domAttempt = await this.tryDOMClick(action, context);
+    if (domAttempt.ok) return domAttempt;
+
+    const stagehandAttempt = await this.tryStagehandClick(action, context);
+    if (stagehandAttempt.ok) return stagehandAttempt;
+
+    return this.tryMagnitudeClick(action, context, domAttempt.error || stagehandAttempt.error);
+  }
+
+  private async tryDOMFill(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): Promise<ExecutionAttempt> {
+    const targets = this.resolveTargetFields(action, context);
+    if (targets.length === 0) {
+      return {
+        ok: false,
+        layer: 'dom',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'DOM fill could not resolve any target fields.',
+        error: 'no_target_fields',
+      };
+    }
+
+    const emptyTargets = targets.filter((field) => field.isEmpty && !field.isDisabled && field.isVisible);
+    if (emptyTargets.length === 0) {
+      return {
+        ok: true,
+        layer: 'dom',
+        fieldsAttempted: targets.length,
+        fieldsFilled: targets.length,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Target fields already appear filled; no DOM fill needed.',
+      };
+    }
+
+    return {
+      ok: false,
+      layer: 'dom',
+      fieldsAttempted: emptyTargets.length,
+      fieldsFilled: 0,
+      costUsd: 0,
+      pageNavigated: false,
+      summary: 'DOM fill skipped because decision actions do not yet include concrete field values.',
+      error: 'missing_field_values',
+    };
+  }
+
+  private async tryStagehandFill(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): Promise<ExecutionAttempt> {
+    if (!this.adapter.observe) {
+      return {
+        ok: false,
+        layer: 'stagehand',
+        fieldsAttempted: this.resolveTargetFields(action, context).length,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Stagehand fill unavailable because adapter.observe() is not implemented.',
+        error: 'observe_unavailable',
+      };
+    }
+
+    try {
+      await this.adapter.observe('Identify the visible fields relevant to the current application step.');
+      const beforeUrl = this.safePageUrl();
+      const fieldLabels = this.resolveTargetFields(action, context).map((field) => field.label);
+      const result = await this.adapter.act(
+        [
+          'Fill the visible application form fields for this step.',
+          fieldLabels.length > 0 ? `Prioritize these field labels: ${fieldLabels.join(', ')}.` : 'Prioritize the visible empty fields on the page.',
+          'Use the applicant profile and runtime context already available to the adapter.',
+          'Do not click Next, Submit, or any final submission button.',
+        ].join(' '),
+      );
+
+      return {
+        ok: result.success,
+        layer: 'stagehand',
+        fieldsAttempted: fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length,
+        fieldsFilled: result.success ? (fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length) : 0,
+        costUsd: 0,
+        pageNavigated: beforeUrl !== this.safePageUrl(),
+        summary: result.message || 'Stagehand fill attempt completed.',
+        error: result.success ? undefined : result.message,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        layer: 'stagehand',
+        fieldsAttempted: this.resolveTargetFields(action, context).length,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Stagehand fill attempt failed.',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async tryMagnitudeFill(
+    action: DecisionAction,
+    context: PageDecisionContext,
+    priorError?: string,
+  ): Promise<ExecutionAttempt> {
+    try {
+      const beforeUrl = this.safePageUrl();
+      const fieldLabels = this.resolveTargetFields(action, context).map((field) => field.label);
+      const result = await this.adapter.act(
+        [
+          'Fill the current job application form fields.',
+          fieldLabels.length > 0 ? `Focus on these fields: ${fieldLabels.join(', ')}.` : 'Focus on the visible empty fields.',
+          'Use the applicant profile already available in your runtime context.',
+          'Do not click any final submit button.',
+          priorError ? `Previous lower-tier error: ${priorError}.` : '',
+        ].filter(Boolean).join(' '),
+      );
+
+      return {
+        ok: result.success,
+        layer: 'magnitude',
+        fieldsAttempted: fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length,
+        fieldsFilled: result.success ? (fieldLabels.length || context.fields.filter((field) => field.isVisible && field.isEmpty).length) : 0,
+        costUsd: 0,
+        pageNavigated: beforeUrl !== this.safePageUrl(),
+        summary: result.message || 'Magnitude fill attempt completed.',
+        error: result.success ? undefined : result.message,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        layer: 'magnitude',
+        fieldsAttempted: this.resolveTargetFields(action, context).length,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Magnitude fill attempt failed.',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async tryDOMClick(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): Promise<ExecutionAttempt> {
+    const selector = this.resolveTargetButtonSelector(action, context);
+    if (!selector) {
+      return {
+        ok: false,
+        layer: 'dom',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'DOM click could not resolve a button target.',
+        error: 'no_click_target',
+      };
+    }
+
+    try {
+      const beforeUrl = this.safePageUrl();
+      await this.page.locator(selector).first().click({ timeout: 3000 });
+      await this.page.waitForTimeout(750);
+      return {
+        ok: true,
+        layer: 'dom',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: beforeUrl !== this.safePageUrl(),
+        summary: `Clicked ${selector} via DOM.`,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        layer: 'dom',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: `DOM click failed for ${selector}.`,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async tryStagehandClick(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): Promise<ExecutionAttempt> {
+    if (!this.adapter.observe) {
+      return {
+        ok: false,
+        layer: 'stagehand',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Stagehand click unavailable because adapter.observe() is not implemented.',
+        error: 'observe_unavailable',
+      };
+    }
+
+    try {
+      await this.adapter.observe('Identify the primary next interactive button on this page.');
+      const beforeUrl = this.safePageUrl();
+      const result = await this.adapter.act(this.buildClickInstruction(action, context));
+      return {
+        ok: result.success,
+        layer: 'stagehand',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: beforeUrl !== this.safePageUrl(),
+        summary: result.message || 'Stagehand click attempt completed.',
+        error: result.success ? undefined : result.message,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        layer: 'stagehand',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Stagehand click attempt failed.',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async tryMagnitudeClick(
+    action: DecisionAction,
+    context: PageDecisionContext,
+    priorError?: string,
+  ): Promise<ExecutionAttempt> {
+    try {
+      const beforeUrl = this.safePageUrl();
+      const result = await this.adapter.act(
+        [this.buildClickInstruction(action, context), priorError ? `Previous lower-tier error: ${priorError}.` : '']
+          .filter(Boolean)
+          .join(' '),
+      );
+      return {
+        ok: result.success,
+        layer: 'magnitude',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: beforeUrl !== this.safePageUrl(),
+        summary: result.message || 'Magnitude click attempt completed.',
+        error: result.success ? undefined : result.message,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        layer: 'magnitude',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Magnitude click attempt failed.',
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async executeAdapterAuthAction(instruction: string): Promise<ExecutionAttempt> {
+    try {
+      const beforeUrl = this.safePageUrl();
+      const result = await this.adapter.act(instruction);
+      return {
+        ok: result.success,
+        layer: this.adapter.observe ? 'stagehand' : 'magnitude',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: beforeUrl !== this.safePageUrl(),
+        summary: result.message || 'Adapter auth action completed.',
+        error: result.success ? undefined : result.message,
+        terminal: !result.success,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        layer: this.adapter.observe ? 'stagehand' : 'magnitude',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'Adapter auth action failed.',
+        error: error instanceof Error ? error.message : String(error),
+        terminal: true,
+      };
+    }
+  }
+
+  private async expandRepeaters(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): Promise<ExecutionAttempt> {
+    const targetLabel = normalizeText(action.target);
+    const repeaters = targetLabel
+      ? context.repeaters.filter((repeater) => normalizeText(repeater.label).includes(targetLabel))
+      : context.repeaters;
+
+    if (repeaters.length === 0) {
+      return {
+        ok: false,
+        layer: 'dom',
+        fieldsAttempted: 0,
+        fieldsFilled: 0,
+        costUsd: 0,
+        pageNavigated: false,
+        summary: 'No repeater add buttons were available to expand.',
+        error: 'no_repeaters',
+      };
+    }
+
+    let clicked = 0;
+    const beforeUrl = this.safePageUrl();
+    for (const repeater of repeaters) {
+      try {
+        await this.page.locator(repeater.addButtonSelector).first().click({ timeout: 3000 });
+        clicked++;
+        await this.page.waitForTimeout(250);
+      } catch {
+        // Keep going so one bad repeater does not hide the rest.
+      }
+    }
+
+    return {
+      ok: clicked > 0,
+      layer: 'dom',
+      fieldsAttempted: repeaters.length,
+      fieldsFilled: clicked,
+      costUsd: 0,
+      pageNavigated: beforeUrl !== this.safePageUrl(),
+      summary: clicked > 0
+        ? `Expanded ${clicked} repeater section(s).`
+        : 'Failed to click any repeater add buttons.',
+      error: clicked > 0 ? undefined : 'repeater_click_failed',
+    };
+  }
+
+  private resolveTargetFields(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): FieldSnapshot[] {
+    const visibleEditableFields = context.fields.filter(
+      (field) => field.isVisible && !field.isDisabled,
+    );
+
+    if (!action.fieldsToFill || action.fieldsToFill.length === 0) {
+      return visibleEditableFields.filter((field) => field.isEmpty);
+    }
+
+    const requested = action.fieldsToFill.map(normalizeText);
+    return visibleEditableFields.filter((field) => {
+      const label = normalizeText(field.label);
+      return requested.some((target) => label === target || label.includes(target) || target.includes(label));
+    });
+  }
+
+  private resolveTargetButtonSelector(
+    action: DecisionAction,
+    context: PageDecisionContext,
+  ): string | null {
+    if (action.target && looksLikeSelector(action.target)) {
+      return action.target;
+    }
+
+    const buttons = context.buttons.filter((button) => !button.isDisabled);
+    const target = normalizeText(action.target);
+    if (target) {
+      const directMatch = buttons.find((button) =>
+        normalizeText(button.selector) === target ||
+        normalizeText(button.automationId) === target ||
+        normalizeText(button.text) === target ||
+        normalizeText(button.text).includes(target),
+      );
+      if (directMatch) return directMatch.selector;
+    }
+
+    switch (action.action) {
+      case 'click_next':
+        return buttons.find((button) =>
+          button.role === 'navigation' ||
+          /next|continue|save and continue|review/i.test(button.text),
+        )?.selector ?? null;
+      case 'click_apply':
+        return buttons.find((button) =>
+          /apply( now)?|start application|easy apply/i.test(button.text) &&
+          !/submit/i.test(button.text),
+        )?.selector ?? null;
+      case 'dismiss_popup':
+        return buttons.find((button) =>
+          /close|dismiss|not now|maybe later|skip|accept/i.test(button.text),
+        )?.selector ?? null;
+      default:
+        return null;
+    }
+  }
+
+  private buildClickInstruction(action: DecisionAction, context: PageDecisionContext): string {
+    const target = this.resolveTargetButtonSelector(action, context) || action.target || 'the best matching visible button';
+    switch (action.action) {
+      case 'click_next':
+        return `Click the next-step navigation button (${target}) for the current application step. Do not click any final submit button.`;
+      case 'click_apply':
+        return `Click the initial apply/start-application button (${target}) if it begins the application flow. Do not click any final submit button.`;
+      case 'dismiss_popup':
+        return `Dismiss the visible popup or consent overlay using ${target}. Avoid navigation or final submission buttons.`;
+      default:
+        return `Click ${target} safely without submitting the application.`;
+    }
+  }
+
+  private safePageUrl(): string {
+    try {
+      return this.page.url();
+    } catch {
+      return '';
+    }
+  }
+}

--- a/packages/ghosthands/src/engine/decision/index.ts
+++ b/packages/ghosthands/src/engine/decision/index.ts
@@ -1,5 +1,5 @@
 export * from './types';
-export { PageDecisionEngine } from './PageDecisionEngine';
+export { PageDecisionEngine, type OnTokenUsage } from './PageDecisionEngine';
 export { PageSnapshotBuilder } from './pageSnapshotBuilder';
 export { DecisionLoopRunner } from './DecisionLoopRunner';
 export { ActionExecutor } from './actionExecutor';

--- a/packages/ghosthands/src/engine/decision/index.ts
+++ b/packages/ghosthands/src/engine/decision/index.ts
@@ -1,0 +1,17 @@
+export * from './types';
+export { PageDecisionEngine } from './PageDecisionEngine';
+export { PageSnapshotBuilder } from './pageSnapshotBuilder';
+export { DecisionLoopRunner } from './DecisionLoopRunner';
+export { ActionExecutor } from './actionExecutor';
+export {
+  checkTermination,
+  MAX_CONSECUTIVE_FAILURES,
+  MAX_ITERATIONS,
+  MAX_SAME_PAGE,
+} from './terminationDetector';
+export {
+  buildSystemPrompt,
+  buildUserMessage,
+  DECISION_TOOL,
+  PLATFORM_GUARDRAILS,
+} from './prompts';

--- a/packages/ghosthands/src/engine/decision/pageSnapshotBuilder.ts
+++ b/packages/ghosthands/src/engine/decision/pageSnapshotBuilder.ts
@@ -35,7 +35,10 @@ async function safeExtract<T>(fn: () => Promise<T>, fallback: T): Promise<Extrac
 }
 
 export class PageSnapshotBuilder {
-  constructor(private readonly platform?: string) {}
+  constructor(
+    private readonly platform?: string,
+    private readonly viewportOnly: boolean = true,
+  ) {}
 
   async buildSnapshot(
     page: Page,
@@ -44,6 +47,10 @@ export class PageSnapshotBuilder {
     const url = page.url();
     const platform = this.platform || detectPlatform(url);
     const scanner = new PageScanner(page, platform);
+
+    // Inject shadow DOM traversal helpers so repeater detection and fingerprinting
+    // can reach elements inside shadow roots (SmartRecruiters, Workday, etc.)
+    await this.injectShadowDOMHelpers(page);
 
     const scanResult = await safeExtract(
       async () => scanner.scan(),
@@ -138,13 +145,56 @@ export class PageSnapshotBuilder {
       observedAt: Date.now(),
     };
 
+    // Filter to viewport-visible elements only to avoid exposing offscreen
+    // submit buttons and future-step CTAs to the LLM prematurely
+    if (this.viewportOnly) {
+      const visibleSelectors = await this.getViewportVisibleSelectors(page, [
+        ...snapshot.fields.map((f) => f.selector),
+        ...snapshot.buttons.map((b) => b.selector),
+      ]);
+      snapshot.fields = snapshot.fields.filter((f) => visibleSelectors.has(f.selector));
+      snapshot.buttons = snapshot.buttons.filter((b) => visibleSelectors.has(b.selector));
+    }
+
     return PageDecisionContextSchema.parse(snapshot);
+  }
+
+  /**
+   * Returns the set of selectors that are within the current viewport bounds.
+   */
+  private async getViewportVisibleSelectors(
+    page: Page,
+    selectors: string[],
+  ): Promise<Set<string>> {
+    try {
+      const visible = await page.evaluate((sels: string[]) => {
+        const vh = window.innerHeight;
+        const result: string[] = [];
+        for (const sel of sels) {
+          try {
+            const el = document.querySelector(sel);
+            if (!el) continue;
+            const rect = el.getBoundingClientRect();
+            // Element is at least partially in viewport
+            if (rect.bottom > 0 && rect.top < vh && rect.width > 0 && rect.height > 0) {
+              result.push(sel);
+            }
+          } catch { /* skip invalid selectors */ }
+        }
+        return result;
+      }, selectors);
+      return new Set(visible);
+    } catch {
+      // On failure, include all elements (safe fallback)
+      return new Set(selectors);
+    }
   }
 
   private async extractHeadings(page: Page): Promise<string[]> {
     return page.evaluate(() => {
+      const ff = (window as Window & { __ff?: any }).__ff;
       const selectors = 'h1, h2, h3, h4, legend, [role="heading"]';
-      const nodes = Array.from(document.querySelectorAll<HTMLElement>(selectors));
+      const nodes: HTMLElement[] = ff?.queryAll?.(selectors) ?? Array.from(document.querySelectorAll<HTMLElement>(selectors));
       const visible = nodes.filter((node) => {
         const rect = node.getBoundingClientRect();
         if (rect.width <= 0 || rect.height <= 0) return false;
@@ -301,12 +351,16 @@ export class PageSnapshotBuilder {
     page: Page,
   ): Promise<PageDecisionContext['fingerprint']> {
     const fingerprint = await page.evaluate(() => {
-      const headingNode = document.querySelector<HTMLElement>('h1, h2, h3, [role="heading"]');
+      const ff = (window as Window & { __ff?: any }).__ff;
+      const qAll = <T extends Element = HTMLElement>(selector: string): T[] =>
+        ff?.queryAll?.(selector) ?? Array.from(document.querySelectorAll<T>(selector));
+
+      const headingNode = qAll<HTMLElement>('h1, h2, h3, [role="heading"]')[0] ?? null;
       const heading = (headingNode?.textContent || '').trim().substring(0, 60);
 
-      const fields = Array.from(document.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(
+      const fields = qAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(
         'input:not([type="hidden"]), select, textarea',
-      ));
+      );
       let fieldCount = 0;
       let filledCount = 0;
       for (const field of fields) {
@@ -451,5 +505,72 @@ export class PageSnapshotBuilder {
 
       return null;
     });
+  }
+
+  /**
+   * Inject window.__ff shadow DOM traversal helpers into the page context
+   * so that repeater detection, fingerprinting, and heading extraction
+   * can pierce shadow roots (critical for SmartRecruiters, Workday, etc.)
+   */
+  private async injectShadowDOMHelpers(page: Page): Promise<void> {
+    try {
+      await page.evaluate(() => {
+        if ((window as any).__ff) return; // Already injected
+
+        function collectShadowRoots(node: Node): ShadowRoot[] {
+          const roots: ShadowRoot[] = [];
+          if (node instanceof Element && node.shadowRoot) {
+            roots.push(node.shadowRoot);
+          }
+          for (const child of Array.from(node.childNodes)) {
+            roots.push(...collectShadowRoots(child));
+          }
+          return roots;
+        }
+
+        function queryAll<T extends Element = HTMLElement>(selector: string): T[] {
+          const results = new Set<T>();
+          const queue: (Document | ShadowRoot)[] = [document];
+          while (queue.length > 0) {
+            const root = queue.shift()!;
+            for (const el of Array.from(root.querySelectorAll<T>(selector))) {
+              results.add(el);
+            }
+            // Discover shadow roots within this root
+            for (const el of Array.from(root.querySelectorAll('*'))) {
+              if (el.shadowRoot) queue.push(el.shadowRoot);
+            }
+          }
+          return Array.from(results);
+        }
+
+        function rootParent(node: Node | null): Element | null {
+          if (!node) return null;
+          const parent = node.parentNode;
+          if (!parent) return null;
+          if (parent instanceof ShadowRoot) return parent.host;
+          return parent instanceof Element ? parent : null;
+        }
+
+        function closestCrossRoot(el: Element | null, selector: string): Element | null {
+          let current: Element | null = el;
+          while (current) {
+            const match = current.closest(selector);
+            if (match) return match;
+            const root = current.getRootNode();
+            if (root instanceof ShadowRoot) {
+              current = root.host;
+            } else {
+              break;
+            }
+          }
+          return null;
+        }
+
+        (window as any).__ff = { queryAll, rootParent, closestCrossRoot };
+      });
+    } catch {
+      // Non-fatal — fall back to document-only queries
+    }
   }
 }

--- a/packages/ghosthands/src/engine/decision/pageSnapshotBuilder.ts
+++ b/packages/ghosthands/src/engine/decision/pageSnapshotBuilder.ts
@@ -1,0 +1,455 @@
+import type { Page } from 'playwright';
+import { detectPageType, detectPlatform } from '../PageObserver';
+import { PageScanner } from '../v3/PageScanner';
+import { PLATFORM_GUARDRAILS } from './prompts';
+import type { ActionHistoryEntry, PageDecisionContext } from './types';
+import { PageDecisionContextSchema } from './types';
+
+type ExtractorResult<T> = {
+  ok: boolean;
+  value: T;
+};
+
+function hashString(value: string): string {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i++) {
+    hash = ((hash << 5) + hash + value.charCodeAt(i)) & 0xffffffff;
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function guardrailHintsFor(platform: string): string[] {
+  const raw = PLATFORM_GUARDRAILS[platform] ?? PLATFORM_GUARDRAILS.other;
+  return raw
+    .split('\n')
+    .map((line) => line.trim().replace(/^-+\s*/, ''))
+    .filter(Boolean);
+}
+
+async function safeExtract<T>(fn: () => Promise<T>, fallback: T): Promise<ExtractorResult<T>> {
+  try {
+    return { ok: true, value: await fn() };
+  } catch {
+    return { ok: false, value: fallback };
+  }
+}
+
+export class PageSnapshotBuilder {
+  constructor(private readonly platform?: string) {}
+
+  async buildSnapshot(
+    page: Page,
+    actionHistory: ActionHistoryEntry[] = [],
+  ): Promise<PageDecisionContext> {
+    const url = page.url();
+    const platform = this.platform || detectPlatform(url);
+    const scanner = new PageScanner(page, platform);
+
+    const scanResult = await safeExtract(
+      async () => scanner.scan(),
+      {
+        url,
+        platform,
+        pageType: 'unknown',
+        pageLabel: undefined,
+        fields: [],
+        buttons: [],
+        scrollHeight: 0,
+        viewportHeight: 0,
+        timestamp: Date.now(),
+      } as Awaited<ReturnType<PageScanner['scan']>>,
+    );
+
+    const [
+      titleResult,
+      pageTypeResult,
+      headingsResult,
+      repeatersResult,
+      fingerprintResult,
+      blockerResult,
+      stepContextResult,
+    ] = await Promise.all([
+      safeExtract(async () => page.title(), ''),
+      safeExtract(async () => detectPageType(page), scanResult.value.pageType ?? 'unknown'),
+      safeExtract(async () => this.extractHeadings(page), [] as string[]),
+      safeExtract(async () => this.detectRepeaters(page), [] as PageDecisionContext['repeaters']),
+      safeExtract(async () => this.extractFingerprint(page), {
+        heading: scanResult.value.pageLabel ?? '',
+        fieldCount: scanResult.value.fields.length,
+        filledCount: scanResult.value.fields.filter((field) => !field.isEmpty).length,
+        activeStep: '',
+        hash: hashString(
+          `${scanResult.value.pageLabel ?? ''}|${scanResult.value.fields.length}|${scanResult.value.fields.filter((field) => !field.isEmpty).length}`,
+        ),
+      }),
+      safeExtract(async () => this.detectBlocker(page), {
+        detected: false,
+        type: null,
+        confidence: 0,
+      }),
+      safeExtract(async () => this.extractStepContext(page), null),
+    ]);
+
+    const totalExtractors = 8;
+    const successfulExtractors = [
+      scanResult.ok,
+      titleResult.ok,
+      pageTypeResult.ok,
+      headingsResult.ok,
+      repeatersResult.ok,
+      fingerprintResult.ok,
+      blockerResult.ok,
+      stepContextResult.ok,
+    ].filter(Boolean).length;
+
+    const snapshot: PageDecisionContext = {
+      url,
+      title: titleResult.value,
+      platform,
+      pageType: pageTypeResult.value || scanResult.value.pageType || 'unknown',
+      headings: headingsResult.value,
+      fields: scanResult.value.fields.map((field) => ({
+        id: field.id,
+        selector: field.selector,
+        label: field.label || field.name || field.fieldId || field.id,
+        fieldType: field.fieldType,
+        isRequired: field.isRequired,
+        isVisible: field.isVisible,
+        isDisabled: field.isDisabled,
+        isEmpty: field.isEmpty,
+        currentValue: field.currentValue ?? '',
+        options: field.options,
+        groupKey: field.groupKey,
+      })),
+      buttons: scanResult.value.buttons.map((button) => ({
+        selector: button.selector,
+        text: button.text,
+        role: button.role,
+        isDisabled: button.isDisabled,
+        automationId: button.automationId,
+      })),
+      stepContext: stepContextResult.value,
+      repeaters: repeatersResult.value,
+      fingerprint: fingerprintResult.value,
+      blocker: blockerResult.value,
+      actionHistory: actionHistory.slice(-10),
+      guardrailHints: guardrailHintsFor(platform),
+      observationConfidence: Math.min(1, successfulExtractors / totalExtractors),
+      observedAt: Date.now(),
+    };
+
+    return PageDecisionContextSchema.parse(snapshot);
+  }
+
+  private async extractHeadings(page: Page): Promise<string[]> {
+    return page.evaluate(() => {
+      const selectors = 'h1, h2, h3, h4, legend, [role="heading"]';
+      const nodes = Array.from(document.querySelectorAll<HTMLElement>(selectors));
+      const visible = nodes.filter((node) => {
+        const rect = node.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return false;
+        const style = window.getComputedStyle(node);
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          node.getAttribute('aria-hidden') !== 'true'
+        );
+      });
+
+      return Array.from(new Set(
+        visible
+          .map((node) => (node.textContent || '').replace(/\s+/g, ' ').trim())
+          .filter(Boolean),
+      )).slice(0, 25);
+    });
+  }
+
+  private async detectRepeaters(page: Page): Promise<PageDecisionContext['repeaters']> {
+    return page.evaluate(() => {
+      const repeaters: PageDecisionContext['repeaters'] = [];
+      const addPattern = /^\+?\s*add\b/i;
+      const ff = (window as Window & { __ff?: any }).__ff;
+
+      const queryAll = (selector: string): HTMLElement[] =>
+        Array.from(ff?.queryAll?.(selector) ?? document.querySelectorAll<HTMLElement>(selector));
+
+      const rootParent = (node: Node | null): Element | null => {
+        if (!node) return null;
+        if (ff?.rootParent) return ff.rootParent(node);
+        return (node as Element).parentElement ?? null;
+      };
+
+      const closestCrossRoot = (el: Element | null, selector: string): Element | null => {
+        if (!el) return null;
+        if (ff?.closestCrossRoot) return ff.closestCrossRoot(el, selector);
+        return el.closest(selector);
+      };
+
+      const isWithinCrossRoot = (node: Element | null, ancestor: Element | null): boolean => {
+        let current: Element | null = node;
+        while (current) {
+          if (current === ancestor) return true;
+          current = rootParent(current);
+        }
+        return false;
+      };
+
+      const queryWithinCrossRoot = (ancestor: Element | null, selector: string): HTMLElement[] => {
+        if (!ancestor) return [];
+        return queryAll(selector).filter((candidate) => isWithinCrossRoot(candidate, ancestor));
+      };
+
+      const buttons = queryAll('button, [role="button"], a.add-btn, .add-btn');
+
+      for (const button of buttons) {
+        const rect = button.getBoundingClientRect();
+        if (rect.width === 0 || rect.height === 0) continue;
+
+        const style = window.getComputedStyle(button);
+        if (style.display === 'none' || style.visibility === 'hidden') continue;
+        if (button.getAttribute('aria-hidden') === 'true') continue;
+        if (button.hasAttribute('disabled') || button.getAttribute('aria-disabled') === 'true') continue;
+
+        const text = (button.textContent || '').trim();
+        if (!addPattern.test(text)) continue;
+
+        const card = closestCrossRoot(
+          button,
+          '.card, .section, [class*="section"], [class*="card"], [data-automation-id*="Section"], [data-automation-id*="panel"], [class*="Panel"], [class*="panel"]',
+        );
+
+        let label = '';
+        if (card) {
+          const heading = queryWithinCrossRoot(
+            card,
+            'h2, h3, h4, [class*="heading"], [class*="title"], [data-automation-id*="sectionHeader"], [data-automation-id*="Title"], legend, [class*="legend"]',
+          )[0];
+          label = heading?.textContent?.trim() || '';
+        }
+
+        if (!label) {
+          let current: Element | null = rootParent(button);
+          while (current && !label) {
+            const prev = current.previousElementSibling;
+            if (prev) {
+              if (['H2', 'H3', 'H4', 'LEGEND'].includes(prev.tagName)) {
+                label = prev.textContent?.trim() || '';
+              }
+              const header = queryWithinCrossRoot(
+                prev,
+                '[data-automation-id*="sectionHeader"], [data-automation-id*="Title"]',
+              )[0];
+              if (header) label = header.textContent?.trim() || '';
+            }
+            current = rootParent(current);
+            if (current === card) break;
+          }
+        }
+
+        if (!label) {
+          label = button.getAttribute('aria-label')?.trim() || text;
+        }
+
+        let currentCount = 0;
+        if (card) {
+          const allText = card.textContent || '';
+          const sectionBase = label.replace(/\s*\d+$/, '').trim();
+          if (sectionBase) {
+            const numberedRe = new RegExp(
+              `${sectionBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+\\d+`,
+              'gi',
+            );
+            const matches = allText.match(numberedRe);
+            if (matches) {
+              currentCount = new Set(matches.map((match) => match.trim().toLowerCase())).size;
+            }
+          }
+
+          if (currentCount === 0) {
+            const list = queryWithinCrossRoot(
+              card,
+              '.repeater-list, [class*="repeater"], [class*="entries"], [data-automation-id*="itemList"], [data-automation-id*="entryList"]',
+            )[0];
+            if (list) currentCount = list.children.length;
+          }
+
+          if (currentCount === 0) {
+            const groups = queryWithinCrossRoot(card, 'fieldset, [class*="entry"], [class*="item-group"]');
+            if (groups.length > 0) currentCount = groups.length;
+          }
+
+          if (currentCount === 0) {
+            const inputs = queryWithinCrossRoot(card, 'input[type="text"], textarea');
+            currentCount = inputs.some((input) => (input as HTMLInputElement).value.trim()) ? 1 : 0;
+          }
+        }
+
+        const marker = `gh-decision-repeater-${repeaters.length}`;
+        button.setAttribute('data-gh-decision-repeater', marker);
+        repeaters.push({
+          label,
+          addButtonSelector: `[data-gh-decision-repeater="${marker}"]`,
+          currentCount,
+        });
+      }
+
+      return repeaters;
+    });
+  }
+
+  private async extractFingerprint(
+    page: Page,
+  ): Promise<PageDecisionContext['fingerprint']> {
+    const fingerprint = await page.evaluate(() => {
+      const headingNode = document.querySelector<HTMLElement>('h1, h2, h3, [role="heading"]');
+      const heading = (headingNode?.textContent || '').trim().substring(0, 60);
+
+      const fields = Array.from(document.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(
+        'input:not([type="hidden"]), select, textarea',
+      ));
+      let fieldCount = 0;
+      let filledCount = 0;
+      for (const field of fields) {
+        const rect = field.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          fieldCount++;
+          if (field.value && field.value.trim()) filledCount++;
+        }
+      }
+
+      const activeSelectors = [
+        '[aria-current="step"]',
+        '[aria-current="true"]',
+        '.active-step',
+        '.current-step',
+        'li.active',
+        'a.active',
+        '[class*="activeSection"]',
+        '[class*="currentSection"]',
+      ];
+      let activeStep = '';
+      for (const selector of activeSelectors) {
+        const active = document.querySelector<HTMLElement>(selector);
+        if (active) {
+          activeStep = (active.textContent || '').trim().substring(0, 40);
+          break;
+        }
+      }
+
+      return { heading, fieldCount, filledCount, activeStep };
+    });
+
+    const base = `${fingerprint.heading}|fields:${fingerprint.fieldCount}|filled:${fingerprint.filledCount}|active:${fingerprint.activeStep}`;
+    return {
+      ...fingerprint,
+      hash: hashString(base),
+    };
+  }
+
+  private async detectBlocker(
+    page: Page,
+  ): Promise<PageDecisionContext['blocker']> {
+    return page.evaluate(() => {
+      const bodyText = (document.body?.innerText || '').toLowerCase();
+      const passwordField = document.querySelector<HTMLInputElement>('input[type="password"]');
+
+      const captchaSignals = [
+        'captcha',
+        'recaptcha',
+        'hcaptcha',
+        'turnstile',
+        'not a robot',
+        'verify you are human',
+      ];
+      const verificationSignals = [
+        'verification code',
+        'security code',
+        'two-factor',
+        '2fa',
+      ];
+
+      if (captchaSignals.some((signal) => bodyText.includes(signal))) {
+        return {
+          detected: true,
+          type: 'captcha',
+          confidence: 0.95,
+        };
+      }
+
+      if (verificationSignals.some((signal) => bodyText.includes(signal))) {
+        return {
+          detected: true,
+          type: 'verification',
+          confidence: 0.75,
+        };
+      }
+
+      if (passwordField && /sign in|log in|login|password/i.test(bodyText)) {
+        return {
+          detected: true,
+          type: 'login',
+          confidence: 0.7,
+        };
+      }
+
+      return {
+        detected: false,
+        type: null,
+        confidence: 0,
+      };
+    });
+  }
+
+  private async extractStepContext(
+    page: Page,
+  ): Promise<PageDecisionContext['stepContext']> {
+    return page.evaluate(() => {
+      const bodyText = (document.body?.innerText || '').replace(/\s+/g, ' ').trim();
+      const textMatch = bodyText.match(/\b(step)\s*(\d+)\s*(?:of|\/)\s*(\d+)\b/i);
+      if (textMatch) {
+        return {
+          label: textMatch[0],
+          current: Number(textMatch[2]),
+          total: Number(textMatch[3]),
+        };
+      }
+
+      const progressBar = document.querySelector<HTMLElement>('[role="progressbar"][aria-valuenow][aria-valuemax]');
+      if (progressBar) {
+        const current = Number(progressBar.getAttribute('aria-valuenow') || 0);
+        const total = Number(progressBar.getAttribute('aria-valuemax') || 0);
+        if (current > 0 && total > 0) {
+          return {
+            label: progressBar.getAttribute('aria-label') || progressBar.textContent?.trim() || 'progress',
+            current,
+            total,
+          };
+        }
+      }
+
+      const steps = Array.from(document.querySelectorAll<HTMLElement>(
+        '[aria-current="step"], [data-step], li[class*="step"], div[class*="step"], [class*="progress-step"]',
+      )).filter((node) => {
+        const rect = node.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      });
+
+      if (steps.length > 1) {
+        const currentIndex = steps.findIndex((step) =>
+          step.getAttribute('aria-current') === 'step' ||
+          step.getAttribute('aria-current') === 'true' ||
+          /active|current/i.test(step.className),
+        );
+        if (currentIndex >= 0) {
+          return {
+            label: steps[currentIndex].textContent?.trim() || `Step ${currentIndex + 1}`,
+            current: currentIndex + 1,
+            total: steps.length,
+          };
+        }
+      }
+
+      return null;
+    });
+  }
+}

--- a/packages/ghosthands/src/engine/decision/prompts.ts
+++ b/packages/ghosthands/src/engine/decision/prompts.ts
@@ -23,6 +23,9 @@ export const PLATFORM_GUARDRAILS: Record<string, string> = {
   smartrecruiters: [
     'SmartRecruiters may split flows across apply, login, and review steps.',
     'If authentication prompts appear, prefer login or create_account rather than generic click actions.',
+    'SmartRecruiters uses shadow DOM custom elements — "Add" buttons for work experience, education, and other repeatable sections may appear inside shadow roots.',
+    'CRITICAL: Before filling a repeater section, use expand_repeaters to click ALL visible "Add" or "+" buttons to create enough entries for the applicant profile (e.g. multiple work experiences).',
+    'After expanding, re-observe before filling to see the newly created fields.',
     'Any CAPTCHA, turnstile, or verification wall must map to report_blocked.',
   ].join('\n'),
   other: [
@@ -81,6 +84,11 @@ export const DECISION_TOOL: Tool = {
         items: { type: 'string' },
         description: 'Field labels to fill when action is fill_form.',
       },
+      fieldValues: {
+        type: 'object',
+        additionalProperties: { type: 'string' },
+        description: 'Optional map of field_label → value when you can infer exact fill values from the applicant profile. Only for fill_form.',
+      },
     },
     required: ['action', 'reasoning', 'confidence'],
   },
@@ -109,6 +117,11 @@ export function buildSystemPrompt(profileSummary: string, platformGuardrails: st
     '- Use `report_blocked` for CAPTCHA, turnstile, bot checks, or human verification challenges.',
     '- Use `login`, `create_account`, or `enter_verification` when the page is clearly in an auth flow.',
     '- If the page is ambiguous or unstable, use `wait_and_retry` instead of forcing a risky action.',
+    '',
+    'Repeater / Add button policy:',
+    '- If the page has visible "Add", "Add another", "+" buttons for repeatable sections (work experience, education, skills, etc.), use `expand_repeaters` BEFORE `fill_form`.',
+    '- The applicant may have multiple entries (e.g. 3 work experiences); expand enough entries to match their profile.',
+    '- After expanding, wait for new fields to appear before filling them.',
     '',
     'Decision policy:',
     '- Be conservative.',

--- a/packages/ghosthands/src/engine/decision/prompts.ts
+++ b/packages/ghosthands/src/engine/decision/prompts.ts
@@ -1,0 +1,199 @@
+import type { Tool } from '@anthropic-ai/sdk/resources/messages';
+import type { PageDecisionContext } from './types';
+
+const SYSTEM_PROMPT_CACHE = new Map<string, string>();
+
+export const PLATFORM_GUARDRAILS: Record<string, string> = {
+  workday: [
+    'Workday often uses multi-step sections with repeated "Next" buttons.',
+    'Treat any visible "Submit", "Submit Application", or final review CTA as a stop condition, not a click target.',
+    'If password fields are visible, prefer login or create_account over generic form filling.',
+    'Use expand_repeaters when work history or education sections expose visible "Add" controls.',
+  ].join('\n'),
+  greenhouse: [
+    'Greenhouse usually has a single-page application flow with resume upload near the top.',
+    'The initial "Apply" button can be valid, but never click a final "Submit Application" button.',
+    'If the page shows a review/confirmation summary, return stop_for_review or mark_complete.',
+  ].join('\n'),
+  lever: [
+    'Lever often keeps the application on one long page with a final submit button at the bottom.',
+    'Prefer fill_form while editable fields remain visible; never convert a visible submit button into a click.',
+    'Scrolling is acceptable when the page is long and no higher-priority action is clear.',
+  ].join('\n'),
+  smartrecruiters: [
+    'SmartRecruiters may split flows across apply, login, and review steps.',
+    'If authentication prompts appear, prefer login or create_account rather than generic click actions.',
+    'Any CAPTCHA, turnstile, or verification wall must map to report_blocked.',
+  ].join('\n'),
+  other: [
+    'Stay conservative on unfamiliar platforms.',
+    'Prefer fill_form over navigation when visible editable fields remain.',
+    'Never press a button whose text implies final submission.',
+    'Use stop_for_review on read-only review pages and mark_complete only on true confirmations.',
+  ].join('\n'),
+};
+
+export const DECISION_TOOL: Tool = {
+  name: 'page_decision',
+  type: 'custom',
+  strict: true,
+  description:
+    'Return the single safest next navigation action for the current job application page. Never submit the application.',
+  input_schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      action: {
+        type: 'string',
+        enum: [
+          'fill_form',
+          'click_next',
+          'click_apply',
+          'upload_resume',
+          'select_option',
+          'dismiss_popup',
+          'scroll_down',
+          'login',
+          'create_account',
+          'enter_verification',
+          'expand_repeaters',
+          'wait_and_retry',
+          'stop_for_review',
+          'mark_complete',
+          'report_blocked',
+        ],
+      },
+      reasoning: {
+        type: 'string',
+        description: 'Brief justification grounded in the current page state.',
+      },
+      target: {
+        type: 'string',
+        description: 'Optional selector, label, or button text to target.',
+      },
+      confidence: {
+        type: 'number',
+        minimum: 0,
+        maximum: 1,
+      },
+      fieldsToFill: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Field labels to fill when action is fill_form.',
+      },
+    },
+    required: ['action', 'reasoning', 'confidence'],
+  },
+};
+
+export function buildSystemPrompt(profileSummary: string, platformGuardrails: string): string {
+  const cacheKey = `${profileSummary}\n<<<GUARDRAILS>>>\n${platformGuardrails}`;
+  const cached = SYSTEM_PROMPT_CACHE.get(cacheKey);
+  if (cached) return cached;
+
+  const prompt = [
+    'You are a job application navigation agent.',
+    'Your job is to choose exactly one safe next action for the current page of a job application flow.',
+    '',
+    'Primary objective:',
+    '- Move the application forward without losing data, duplicating actions, or triggering final submission.',
+    '',
+    'Hard rules:',
+    '- Never submit the application.',
+    '- Never click any final "Submit", "Submit Application", "Finish", or equivalent CTA.',
+    '- Prefer `fill_form` when editable fields remain visible and empty.',
+    '- Prefer `click_next` only after the visible fields for the current step appear filled or intentionally skipped.',
+    '- Use `click_apply` only for an initial apply/start-application CTA, never for final submission.',
+    '- Use `stop_for_review` when the page looks like a review page or the next obvious action would be final submission.',
+    '- Use `mark_complete` only when the page is clearly a confirmation/success/submitted page.',
+    '- Use `report_blocked` for CAPTCHA, turnstile, bot checks, or human verification challenges.',
+    '- Use `login`, `create_account`, or `enter_verification` when the page is clearly in an auth flow.',
+    '- If the page is ambiguous or unstable, use `wait_and_retry` instead of forcing a risky action.',
+    '',
+    'Decision policy:',
+    '- Be conservative.',
+    '- Output one action only.',
+    '- Prefer the smallest reversible action that advances the flow.',
+    '- Do not invent selectors or fields that are not grounded in the snapshot.',
+    '- If you choose `fill_form`, include the field labels in `fieldsToFill`.',
+    '- If you choose a targeted click, provide `target` when there is a clear button or selector.',
+    '- Confidence should reflect actual certainty from the snapshot, not optimism.',
+    '',
+    'Review / completion guidance:',
+    '- Review pages are usually read-only summaries with a visible final submit button and few or no editable fields.',
+    '- Confirmation pages usually contain thank-you, submitted, received, or success language.',
+    '- If a blocker is detected with high confidence, prioritize `report_blocked` over all other actions.',
+    '',
+    'Platform guardrails:',
+    platformGuardrails || PLATFORM_GUARDRAILS.other,
+    '',
+    'Applicant profile summary:',
+    profileSummary || 'No profile summary provided.',
+    '',
+    'Use the `page_decision` tool for your answer.',
+  ].join('\n');
+
+  SYSTEM_PROMPT_CACHE.set(cacheKey, prompt);
+  return prompt;
+}
+
+export function buildUserMessage(context: PageDecisionContext): string {
+  const fields = context.fields.length > 0
+    ? context.fields.map((field) => {
+      const state = [
+        field.isRequired ? 'required' : 'optional',
+        field.isDisabled ? 'disabled' : 'enabled',
+        field.isVisible ? 'visible' : 'hidden',
+        field.isEmpty ? 'empty' : 'filled',
+      ].join(', ');
+      const options = field.options?.length ? ` options=[${field.options.slice(0, 10).join(', ')}]` : '';
+      return `- ${field.label} | type=${field.fieldType} | state=${state}${options}`;
+    }).join('\n')
+    : '- none';
+
+  const buttons = context.buttons.length > 0
+    ? context.buttons.map((button) =>
+      `- "${button.text || '(no text)'}" | role=${button.role} | selector=${button.selector} | disabled=${button.isDisabled}`,
+    ).join('\n')
+    : '- none';
+
+  const recentHistory = context.actionHistory.slice(-5);
+  const historyBlock = recentHistory.length > 0
+    ? recentHistory.map((entry) =>
+      `- iter=${entry.iteration} action=${entry.action} target=${entry.target || '(none)'} result=${entry.result} layer=${entry.layer ?? 'none'} cost=$${entry.costUsd.toFixed(4)}`,
+    ).join('\n')
+    : '- none';
+
+  const trackedCost = context.actionHistory.reduce((sum, entry) => sum + entry.costUsd, 0);
+  const nextIteration = (recentHistory[recentHistory.length - 1]?.iteration ?? 0) + 1;
+  const stepSummary = context.stepContext
+    ? `${context.stepContext.label || 'step'} (${context.stepContext.current}/${context.stepContext.total})`
+    : 'none';
+
+  return [
+    `URL: ${context.url}`,
+    `Title: ${context.title}`,
+    `Platform: ${context.platform}`,
+    `Page Type: ${context.pageType}`,
+    `Fingerprint: ${context.fingerprint.hash}`,
+    `Fingerprint Summary: heading="${context.fingerprint.heading}" fields=${context.fingerprint.fieldCount} filled=${context.fingerprint.filledCount} activeStep="${context.fingerprint.activeStep}"`,
+    `Step Context: ${stepSummary}`,
+    `Blocker: detected=${context.blocker.detected} type=${context.blocker.type ?? 'none'} confidence=${context.blocker.confidence.toFixed(2)}`,
+    `Observation Confidence: ${context.observationConfidence.toFixed(2)}`,
+    `Guardrail Hints: ${context.guardrailHints.length ? context.guardrailHints.join(' | ') : 'none'}`,
+    `Iteration Info: next_iteration=${nextIteration}`,
+    `Budget Info: tracked_cost_usd=${trackedCost.toFixed(4)} (hard budget enforced externally)`,
+    '',
+    'Visible headings:',
+    ...(context.headings.length > 0 ? context.headings.map((heading) => `- ${heading}`) : ['- none']),
+    '',
+    'Fields:',
+    fields,
+    '',
+    'Buttons:',
+    buttons,
+    '',
+    'Recent action history:',
+    historyBlock,
+  ].join('\n');
+}

--- a/packages/ghosthands/src/engine/decision/prompts.ts
+++ b/packages/ghosthands/src/engine/decision/prompts.ts
@@ -1,6 +1,7 @@
 import type { Tool } from '@anthropic-ai/sdk/resources/messages';
 import type { PageDecisionContext } from './types';
 
+const SYSTEM_PROMPT_CACHE_MAX = 20;
 const SYSTEM_PROMPT_CACHE = new Map<string, string>();
 
 export const PLATFORM_GUARDRAILS: Record<string, string> = {
@@ -38,8 +39,6 @@ export const PLATFORM_GUARDRAILS: Record<string, string> = {
 
 export const DECISION_TOOL: Tool = {
   name: 'page_decision',
-  type: 'custom',
-  strict: true,
   description:
     'Return the single safest next navigation action for the current job application page. Never submit the application.',
   input_schema: {
@@ -146,6 +145,10 @@ export function buildSystemPrompt(profileSummary: string, platformGuardrails: st
     'Use the `page_decision` tool for your answer.',
   ].join('\n');
 
+  if (SYSTEM_PROMPT_CACHE.size >= SYSTEM_PROMPT_CACHE_MAX) {
+    const oldest = SYSTEM_PROMPT_CACHE.keys().next().value;
+    if (oldest !== undefined) SYSTEM_PROMPT_CACHE.delete(oldest);
+  }
   SYSTEM_PROMPT_CACHE.set(cacheKey, prompt);
   return prompt;
 }

--- a/packages/ghosthands/src/engine/decision/terminationDetector.ts
+++ b/packages/ghosthands/src/engine/decision/terminationDetector.ts
@@ -1,0 +1,84 @@
+import type { DecisionAction, DecisionLoopState } from './types';
+
+export const MAX_ITERATIONS = 100;
+export const MAX_SAME_PAGE = 6;
+export const MAX_CONSECUTIVE_FAILURES = 3;
+
+export type TerminationCheck =
+  | { type: 'confirmation'; reason: string }
+  | { type: 'review_page'; reason: string }
+  | { type: 'blocked'; reason: string }
+  | { type: 'stuck'; reason: string }
+  | { type: 'budget_exceeded'; reason: string }
+  | { type: 'max_iterations'; reason: string }
+  | { type: 'error'; reason: string };
+
+function countConsecutiveFailures(loopState: DecisionLoopState): number {
+  let failures = 0;
+  for (let i = loopState.actionHistory.length - 1; i >= 0; i--) {
+    if (loopState.actionHistory[i].result === 'failed') {
+      failures++;
+      continue;
+    }
+    break;
+  }
+  return failures;
+}
+
+export function checkTermination(
+  decision: DecisionAction,
+  loopState: DecisionLoopState,
+  budgetUsd: number,
+): TerminationCheck | null {
+  if (decision.action === 'mark_complete') {
+    return {
+      type: 'confirmation',
+      reason: 'Decision engine marked the application flow as complete.',
+    };
+  }
+
+  if (decision.action === 'stop_for_review') {
+    return {
+      type: 'review_page',
+      reason: 'Decision engine stopped on a review page before final submission.',
+    };
+  }
+
+  if (decision.action === 'report_blocked') {
+    return {
+      type: 'blocked',
+      reason: 'Decision engine detected a blocker that likely requires human review.',
+    };
+  }
+
+  if (loopState.samePageCount >= MAX_SAME_PAGE) {
+    return {
+      type: 'stuck',
+      reason: `Page fingerprint remained unchanged for ${loopState.samePageCount} iterations.`,
+    };
+  }
+
+  if (loopState.loopCostUsd >= budgetUsd) {
+    return {
+      type: 'budget_exceeded',
+      reason: `Loop cost $${loopState.loopCostUsd.toFixed(4)} exceeded budget $${budgetUsd.toFixed(4)}.`,
+    };
+  }
+
+  if (loopState.iteration >= MAX_ITERATIONS) {
+    return {
+      type: 'max_iterations',
+      reason: `Reached max iteration limit (${MAX_ITERATIONS}).`,
+    };
+  }
+
+  const consecutiveFailures = countConsecutiveFailures(loopState);
+  if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+    return {
+      type: 'error',
+      reason: `${consecutiveFailures} consecutive action failures detected.`,
+    };
+  }
+
+  return null;
+}

--- a/packages/ghosthands/src/engine/decision/types.ts
+++ b/packages/ghosthands/src/engine/decision/types.ts
@@ -109,6 +109,7 @@ export const RepeaterSnapshotSchema = z.object({
   label: z.string(),
   addButtonSelector: z.string().min(1),
   currentCount: z.number().int().nonnegative(),
+  targetCount: z.number().int().nonnegative().optional(),
 }).strict();
 
 export type RepeaterSnapshot = z.infer<typeof RepeaterSnapshotSchema>;
@@ -173,6 +174,7 @@ export const DecisionActionSchema = z.object({
   target: z.string().optional(),
   confidence: z.number().min(0).max(1),
   fieldsToFill: z.array(z.string().min(1)).optional(),
+  fieldValues: z.record(z.string(), z.string()).optional(),
 }).strict();
 
 export type DecisionAction = z.infer<typeof DecisionActionSchema>;

--- a/packages/ghosthands/src/engine/decision/types.ts
+++ b/packages/ghosthands/src/engine/decision/types.ts
@@ -211,6 +211,7 @@ export const DecisionLoopStateSchema = z.object({
     'confirmation',
     'review_page',
     'submitted',
+    'blocked',
     'stuck',
     'budget_exceeded',
     'error',

--- a/packages/ghosthands/src/engine/decision/types.ts
+++ b/packages/ghosthands/src/engine/decision/types.ts
@@ -1,0 +1,220 @@
+import { z } from 'zod';
+import type {
+  ButtonModel,
+  ButtonRole,
+  FieldModel,
+  FieldType,
+} from '../v3/v2types';
+
+const FIELD_TYPE_VALUES = [
+  'text',
+  'email',
+  'phone',
+  'number',
+  'date',
+  'textarea',
+  'select',
+  'custom_dropdown',
+  'radio',
+  'aria_radio',
+  'checkbox',
+  'file',
+  'typeahead',
+  'contenteditable',
+  'upload_button',
+  'password',
+  'button_group',
+  'unknown',
+] as const satisfies readonly FieldType[];
+
+const BUTTON_ROLE_VALUES = [
+  'navigation',
+  'submit',
+  'add',
+  'action',
+  'unknown',
+] as const satisfies readonly ButtonRole[];
+
+export const FieldSnapshotSchema = z.object({
+  id: z.string().min(1),
+  selector: z.string().min(1),
+  label: z.string().min(1),
+  fieldType: z.enum(FIELD_TYPE_VALUES),
+  isRequired: z.boolean(),
+  isVisible: z.boolean(),
+  isDisabled: z.boolean(),
+  isEmpty: z.boolean(),
+  currentValue: z.string(),
+  options: z.array(z.string()).optional(),
+  groupKey: z.string().optional(),
+}).strict();
+
+export type FieldSnapshot = z.infer<typeof FieldSnapshotSchema>;
+
+type _FieldSnapshotCompatible = FieldSnapshot extends Pick<
+  FieldModel,
+  | 'id'
+  | 'selector'
+  | 'label'
+  | 'fieldType'
+  | 'isRequired'
+  | 'isVisible'
+  | 'isDisabled'
+  | 'isEmpty'
+  | 'currentValue'
+  | 'options'
+  | 'groupKey'
+> ? true : never;
+
+export const ButtonSnapshotSchema = z.object({
+  selector: z.string().min(1),
+  text: z.string(),
+  role: z.enum(BUTTON_ROLE_VALUES),
+  isDisabled: z.boolean(),
+  automationId: z.string().optional(),
+}).strict();
+
+export type ButtonSnapshot = z.infer<typeof ButtonSnapshotSchema>;
+
+type _ButtonSnapshotCompatible = ButtonSnapshot extends Pick<
+  ButtonModel,
+  'selector' | 'text' | 'role' | 'isDisabled' | 'automationId'
+> ? true : never;
+
+export const ActionHistoryEntrySchema = z.object({
+  iteration: z.number().int().nonnegative(),
+  action: z.string().min(1),
+  target: z.string(),
+  result: z.enum(['success', 'partial', 'failed', 'skipped']),
+  layer: z.enum(['dom', 'stagehand', 'magnitude']).nullable(),
+  costUsd: z.number().min(0),
+  durationMs: z.number().min(0),
+  fieldsAttempted: z.number().int().nonnegative().optional(),
+  fieldsFilled: z.number().int().nonnegative().optional(),
+  pageFingerprint: z.string().min(1),
+  timestamp: z.number().nonnegative(),
+}).strict();
+
+export type ActionHistoryEntry = z.infer<typeof ActionHistoryEntrySchema>;
+
+export const StepContextSchema = z.object({
+  label: z.string(),
+  current: z.number().int().positive(),
+  total: z.number().int().positive(),
+}).strict();
+
+export type StepContext = z.infer<typeof StepContextSchema>;
+
+export const RepeaterSnapshotSchema = z.object({
+  label: z.string(),
+  addButtonSelector: z.string().min(1),
+  currentCount: z.number().int().nonnegative(),
+}).strict();
+
+export type RepeaterSnapshot = z.infer<typeof RepeaterSnapshotSchema>;
+
+export const FingerprintSchema = z.object({
+  heading: z.string(),
+  fieldCount: z.number().int().nonnegative(),
+  filledCount: z.number().int().nonnegative(),
+  activeStep: z.string(),
+  hash: z.string().min(1),
+}).strict();
+
+export type Fingerprint = z.infer<typeof FingerprintSchema>;
+
+export const BlockerSnapshotSchema = z.object({
+  detected: z.boolean(),
+  type: z.string().nullable(),
+  confidence: z.number().min(0).max(1),
+}).strict();
+
+export type BlockerSnapshot = z.infer<typeof BlockerSnapshotSchema>;
+
+export const PageDecisionContextSchema = z.object({
+  url: z.string().url(),
+  title: z.string(),
+  platform: z.string().min(1),
+  pageType: z.string().min(1),
+  headings: z.array(z.string()),
+  fields: z.array(FieldSnapshotSchema),
+  buttons: z.array(ButtonSnapshotSchema),
+  stepContext: StepContextSchema.nullable(),
+  repeaters: z.array(RepeaterSnapshotSchema),
+  fingerprint: FingerprintSchema,
+  blocker: BlockerSnapshotSchema,
+  actionHistory: z.array(ActionHistoryEntrySchema),
+  guardrailHints: z.array(z.string()),
+  observationConfidence: z.number().min(0).max(1),
+  observedAt: z.number().nonnegative(),
+}).strict();
+
+export type PageDecisionContext = z.infer<typeof PageDecisionContextSchema>;
+
+export const DecisionActionSchema = z.object({
+  action: z.enum([
+    'fill_form',
+    'click_next',
+    'click_apply',
+    'upload_resume',
+    'select_option',
+    'dismiss_popup',
+    'scroll_down',
+    'login',
+    'create_account',
+    'enter_verification',
+    'expand_repeaters',
+    'wait_and_retry',
+    'stop_for_review',
+    'mark_complete',
+    'report_blocked',
+  ]),
+  reasoning: z.string().min(1),
+  target: z.string().optional(),
+  confidence: z.number().min(0).max(1),
+  fieldsToFill: z.array(z.string().min(1)).optional(),
+}).strict();
+
+export type DecisionAction = z.infer<typeof DecisionActionSchema>;
+
+export const ExecutorResultSchema = z.object({
+  status: z.enum([
+    'action_succeeded',
+    'action_failed_retryable',
+    'action_failed_terminal',
+    'needs_review',
+  ]),
+  layer: z.enum(['dom', 'stagehand', 'magnitude']).nullable(),
+  fieldsAttempted: z.number().int().nonnegative(),
+  fieldsFilled: z.number().int().nonnegative(),
+  durationMs: z.number().min(0),
+  costUsd: z.number().min(0),
+  pageNavigated: z.boolean(),
+  error: z.string().optional(),
+  summary: z.string().min(1),
+}).strict();
+
+export type ExecutorResult = z.infer<typeof ExecutorResultSchema>;
+
+export const DecisionLoopStateSchema = z.object({
+  iteration: z.number().int().nonnegative(),
+  pagesProcessed: z.number().int().nonnegative(),
+  currentPageFingerprint: z.string().nullable(),
+  previousPageFingerprint: z.string().nullable(),
+  samePageCount: z.number().int().nonnegative(),
+  actionHistory: z.array(ActionHistoryEntrySchema),
+  loopCostUsd: z.number().min(0),
+  terminalState: z.enum([
+    'running',
+    'confirmation',
+    'review_page',
+    'submitted',
+    'stuck',
+    'budget_exceeded',
+    'error',
+    'max_iterations',
+  ]),
+  terminationReason: z.string().nullable(),
+}).strict();
+
+export type DecisionLoopState = z.infer<typeof DecisionLoopStateSchema>;

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -1515,7 +1515,7 @@ export class JobExecutor {
     const workflow = job.execution_mode === 'mastra_decision'
       ? buildDecisionApplyWorkflow(rt, {
           create(options) {
-            const { DecisionLoopRunner } = require('../../engine/decision/index.js');
+            const { DecisionLoopRunner } = require('../engine/decision/index.js');
             return new DecisionLoopRunner({
               page: options.page,
               adapter: options.adapter,
@@ -1524,6 +1524,8 @@ export class JobExecutor {
               budgetUsd: options.budgetUsd,
               anthropicConfig: rt.llmClientConfig?.anthropic,
               model: (rt.job.metadata as Record<string, any>)?.decision_model,
+              previousActionHistory: options.previousActionHistory,
+              previousIteration: options.previousIteration,
               onProgress: options.logEvent
                 ? (event: { type: string; message: string; iteration: number }) => {
                     options.logEvent(`decision_loop_${event.type}`, {

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -23,7 +23,7 @@ import { ResumeProfileLoader } from '../db/resumeProfileLoader.js';
 import { getLogger } from '../monitoring/logger.js';
 import { AgentApplyHandler } from './taskHandlers/agentApplyHandler.js';
 import { getMastra } from '../workflows/mastra/init.js';
-import { buildApplyWorkflow } from '../workflows/mastra/applyWorkflow.js';
+import { buildApplyWorkflow, buildDecisionApplyWorkflow } from '../workflows/mastra/applyWorkflow.js';
 import { isMastraResume, claimResume, persistMastraRunId } from '../workflows/mastra/resumeCoordinator.js';
 import { workflowState, type RuntimeContext, type WorkflowState } from '../workflows/mastra/types.js';
 import {
@@ -217,7 +217,7 @@ export class JobExecutor {
   private canAutoRecoverAuth(job: AutomationJob): boolean {
     const executionMode = (job.execution_mode || '').toLowerCase();
     const jobType = (job.job_type || '').toLowerCase();
-    if (executionMode === 'smart_apply' || executionMode === 'agent_apply') {
+    if (executionMode === 'smart_apply' || executionMode === 'agent_apply' || executionMode === 'mastra_decision') {
       return true;
     }
     return jobType === 'smart_apply' || jobType === 'workday_apply' || jobType === 'agent_apply';
@@ -708,7 +708,7 @@ export class JobExecutor {
       }
 
       // --- MASTRA WORKFLOW PATH ---
-      if (job.execution_mode === 'mastra') {
+      if (job.execution_mode === 'mastra' || job.execution_mode === 'mastra_decision') {
         const logEventFn = (eventType: string, metadata: Record<string, any>) =>
           this.logJobEvent(job.id, eventType, metadata);
         await this.executeMastraWorkflow({
@@ -1509,7 +1509,23 @@ export class JobExecutor {
     };
 
     // Build the workflow (per-job, captures rt via closure)
-    const workflow = buildApplyWorkflow(rt);
+    // For mastra_decision mode, we pass a stub DecisionLoopRunnerFactory.
+    // The actual DecisionLoopRunner is implemented in engine/decision/ and will
+    // be wired here once built. The stub throws a clear error at runtime.
+    const workflow = job.execution_mode === 'mastra_decision'
+      ? buildDecisionApplyWorkflow(rt, {
+          create() {
+            return {
+              async run() {
+                throw new Error(
+                  'DecisionLoopRunner is not yet implemented. ' +
+                  'Wire engine/decision/DecisionLoopRunner into buildDecisionApplyWorkflow().',
+                );
+              },
+            };
+          },
+        })
+      : buildApplyWorkflow(rt);
     const mastra = getMastra();
 
     if (!mastra) {
@@ -1596,8 +1612,17 @@ export class JobExecutor {
 
       run = await registeredWf.createRun({ runId: job.metadata.mastra_run_id });
       await pageContext.initializeRun(run.runId);
+
+      // Determine which step to resume. For mastra_decision mode, the
+      // page_decision_loop step can also suspend for HITL.
+      // When only one step is suspended, Mastra auto-detects it, but we
+      // still resolve the step ID for explicit logging and correctness.
+      const externalResumeStep = job.execution_mode === 'mastra_decision'
+        ? undefined  // Let Mastra auto-detect from persisted snapshot
+        : 'check_blockers_checkpoint';
+
       result = await run.resume({
-        step: 'check_blockers_checkpoint',
+        step: externalResumeStep,
         resumeData: {
           resolutionType,
           resumeNonce: job.metadata.resume_nonce || crypto.randomUUID(),
@@ -1703,14 +1728,22 @@ export class JobExecutor {
         return;
       }
 
-      // Human resolved — resume the Mastra workflow in-process
+      // Human resolved — resume the Mastra workflow in-process.
+      // Determine which step suspended (check_blockers_checkpoint or page_decision_loop).
+      // When only one step is suspended, Mastra auto-detects it, but we explicitly
+      // identify it for logging and correctness when the decision loop also suspends.
+      const suspendedStepId = Array.isArray(result?.suspended) && result.suspended.length > 0
+        ? (typeof result.suspended[0] === 'string' ? result.suspended[0] : result.suspended[0]?.id ?? 'check_blockers_checkpoint')
+        : 'check_blockers_checkpoint';
+
       logger.info('HITL resolved, resuming workflow in-process', {
         jobId: job.id,
         resolutionType: resumeResult.resolutionType,
+        resumeStep: suspendedStepId,
       });
 
       result = await run.resume({
-        step: 'check_blockers_checkpoint',
+        step: suspendedStepId,
         resumeData: {
           resolutionType: resumeResult.resolutionType || 'manual',
           resumeNonce: crypto.randomUUID(),
@@ -1754,7 +1787,7 @@ export class JobExecutor {
       finalState = raw.output as WorkflowState;
     } else if (result?.steps) {
       // Fallback: extract from individual step results
-      const stepKeys = ['execute_handler'];
+      const stepKeys = ['execute_handler', 'page_decision_loop'];
       for (const key of stepKeys) {
         const stepResult = (result.steps as Record<string, any>)[key];
         if (stepResult?.output && typeof stepResult.output === 'object' && 'handler' in stepResult.output) {
@@ -1775,11 +1808,49 @@ export class JobExecutor {
       throw new Error('Mastra workflow returned no extractable state');
     }
 
+    // Persist decision engine metrics if the decision loop was used
+    if (finalState.decisionLoop) {
+      const dl = finalState.decisionLoop as Record<string, any>;
+      const decisionEngineMetrics = {
+        iterations: dl.iteration ?? 0,
+        pages_processed: dl.pagesProcessed ?? 0,
+        terminal_state: dl.terminalState ?? 'unknown',
+        termination_reason: dl.terminationReason ?? null,
+        total_actions: Array.isArray(dl.actionHistory) ? dl.actionHistory.length : 0,
+        loop_cost_usd: dl.loopCostUsd ?? 0,
+        cost_breakdown: Array.isArray(dl.actionHistory) ? {
+          dom_actions: dl.actionHistory.filter((a: any) => a.layer === 'dom').length,
+          stagehand_actions: dl.actionHistory.filter((a: any) => a.layer === 'stagehand').length,
+          magnitude_actions: dl.actionHistory.filter((a: any) => a.layer === 'magnitude').length,
+        } : {},
+      };
+
+      try {
+        await this.supabase
+          .from('gh_automation_jobs')
+          .update({
+            metadata: {
+              ...job.metadata,
+              decision_engine: decisionEngineMetrics,
+            },
+          })
+          .eq('id', job.id);
+
+        // Keep job.metadata in sync for downstream finalization
+        job.metadata = { ...job.metadata, decision_engine: decisionEngineMetrics };
+      } catch (err) {
+        logger.warn('Failed to persist decision engine metrics', {
+          jobId: job.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     if (finalState.handler?.attempted && finalState.handler.taskResult) {
       const taskResult = finalState.handler.taskResult as any;
       // Map execution_mode to a valid final_mode value for the DB constraint.
-      // Valid final_mode values: 'magnitude', 'hybrid', 'smart_apply', 'agent_apply', 'mastra'
-      const VALID_FINAL_MODES = new Set(['magnitude', 'hybrid', 'smart_apply', 'agent_apply', 'mastra']);
+      // Valid final_mode values: 'magnitude', 'hybrid', 'smart_apply', 'agent_apply', 'mastra', 'mastra_decision'
+      const VALID_FINAL_MODES = new Set(['magnitude', 'hybrid', 'smart_apply', 'agent_apply', 'mastra', 'mastra_decision']);
       const finalMode = (job.execution_mode && VALID_FINAL_MODES.has(job.execution_mode)) ? job.execution_mode : 'magnitude';
       const engineResult = {
         success: false,

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -1375,6 +1375,7 @@ export class JobExecutor {
     resumeFilePath: string | null;
     emailVerification?: EmailVerificationService | null;
     logEventFn: (eventType: string, metadata: Record<string, unknown>) => Promise<void>;
+    llmClientConfig?: { anthropic?: import('./taskHandlers/types.js').AnthropicClientConfig };
   }): Promise<void> {
     const {
       job,
@@ -1388,6 +1389,7 @@ export class JobExecutor {
       emailVerification,
       logEventFn,
     } = opts;
+    const llmClientConfig = opts.llmClientConfig;
     const logger = getLogger({ service: 'mastra-executor' });
     const pageContext = new LivePageContextService(
       job.id,
@@ -1412,6 +1414,7 @@ export class JobExecutor {
       logEvent: logEventFn,
       workerId: this.workerId,
       uploadScreenshot: (jid: string, name: string, buf: Buffer) => this.uploadScreenshot(jid, name, buf),
+      llmClientConfig,
 
       // Allow handlers to pause mid-execution for manual user actions (email verification, etc.)
       waitForManualAction: async (actionOpts) => {
@@ -1519,6 +1522,7 @@ export class JobExecutor {
               profile: (rt.job.metadata as Record<string, any>)?.profile ?? {},
               platform: options.platform,
               budgetUsd: options.budgetUsd,
+              anthropicConfig: rt.llmClientConfig?.anthropic,
               model: (rt.job.metadata as Record<string, any>)?.decision_model,
               onProgress: options.logEvent
                 ? (event: { type: string; message: string; iteration: number }) => {

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -1522,6 +1522,7 @@ export class JobExecutor {
               profile: (rt.job.metadata as Record<string, any>)?.profile ?? {},
               platform: options.platform,
               budgetUsd: options.budgetUsd,
+              costTracker: options.costTracker,
               anthropicConfig: rt.llmClientConfig?.anthropic,
               model: (rt.job.metadata as Record<string, any>)?.decision_model,
               previousActionHistory: options.previousActionHistory,

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -1509,20 +1509,27 @@ export class JobExecutor {
     };
 
     // Build the workflow (per-job, captures rt via closure)
-    // For mastra_decision mode, we pass a stub DecisionLoopRunnerFactory.
-    // The actual DecisionLoopRunner is implemented in engine/decision/ and will
-    // be wired here once built. The stub throws a clear error at runtime.
     const workflow = job.execution_mode === 'mastra_decision'
       ? buildDecisionApplyWorkflow(rt, {
-          create() {
-            return {
-              async run() {
-                throw new Error(
-                  'DecisionLoopRunner is not yet implemented. ' +
-                  'Wire engine/decision/DecisionLoopRunner into buildDecisionApplyWorkflow().',
-                );
-              },
-            };
+          create(options) {
+            const { DecisionLoopRunner } = require('../../engine/decision/index.js');
+            return new DecisionLoopRunner({
+              page: options.page,
+              adapter: options.adapter,
+              profile: (rt.job.metadata as Record<string, any>)?.profile ?? {},
+              platform: options.platform,
+              budgetUsd: options.budgetUsd,
+              model: (rt.job.metadata as Record<string, any>)?.decision_model,
+              onProgress: options.logEvent
+                ? (event: { type: string; message: string; iteration: number }) => {
+                    options.logEvent(`decision_loop_${event.type}`, {
+                      iteration: event.iteration,
+                      message: event.message,
+                    });
+                  }
+                : undefined,
+              maxIterations: 100,
+            });
           },
         })
       : buildApplyWorkflow(rt);

--- a/packages/ghosthands/src/workers/JobExecutor.ts
+++ b/packages/ghosthands/src/workers/JobExecutor.ts
@@ -795,7 +795,7 @@ export class JobExecutor {
       // Start periodic blocker check timer (catches blockers even when adapter is stuck)
       // Only for workday_apply — SPA platforms (Greenhouse) cause page.evaluate() to hang,
       // creating contention with Magnitude's own evaluate calls
-      if (handler.type === 'workday_apply') {
+      if (handler.type === 'workday_apply' && job.execution_mode !== 'mastra_decision') {
         blockerCheckInterval = setInterval(async () => {
           if (!adapter || adapter.isPaused?.()) return; // Don't check while paused
           try {
@@ -808,7 +808,14 @@ export class JobExecutor {
           }
         }, PERIODIC_BLOCKER_CHECK_MS);
       } else {
-        logger.debug('[exec] Periodic blocker checks disabled for non-workday handler', { jobId: job.id, handler: handler.type });
+        logger.debug('[exec] Periodic blocker checks disabled', {
+          jobId: job.id,
+          handler: handler.type,
+          executionMode: job.execution_mode,
+          reason: job.execution_mode === 'mastra_decision'
+            ? 'decision loop has built-in blocker detection'
+            : 'non-workday handler',
+        });
       }
 
       // 10. Build TaskContext and delegate to handler (with crash recovery)

--- a/packages/ghosthands/src/workers/JobPoller.ts
+++ b/packages/ghosthands/src/workers/JobPoller.ts
@@ -84,17 +84,10 @@ export class JobPoller {
         // LISTEN state is dropped between transactions. The poll timer
         // below compensates — NOTIFY is a best-effort optimization.
         //
-        // TODO: pg_notify('gh_job_created', ...) is never called anywhere in the codebase.
-        // No trigger on gh_automation_jobs INSERT fires this notification.
-        // LISTEN is effectively a dead path — polling (5s interval) is the actual
-        // job discovery mechanism. To enable instant pickup, add a trigger:
-        //   CREATE OR REPLACE FUNCTION gh_notify_job_created() RETURNS trigger AS $$
-        //   BEGIN
-        //     PERFORM pg_notify('gh_job_created', NEW.id::text);
-        //     RETURN NEW;
-        //   END; $$ LANGUAGE plpgsql;
-        //   CREATE TRIGGER trg_gh_job_created AFTER INSERT ON gh_automation_jobs
-        //     FOR EACH ROW EXECUTE FUNCTION gh_notify_job_created();
+        // NOTE: pg_notify('gh_job_created', ...) IS fired by the VALET API route
+        // (src/api/routes/valet.ts) on job creation/resume. However, LISTEN may
+        // not work reliably through pgbouncer in transaction-pooling mode.
+        // The 5s polling interval compensates as a fallback.
         try {
             await this.pgDirect.query("LISTEN gh_job_created");
             this.pgDirect.on("notification", (_msg: Notification) => {
@@ -112,7 +105,7 @@ export class JobPoller {
         }
 
         // Poll every 5s — primary job discovery mechanism.
-        // NOTIFY is unreliable (no trigger fires it; pgbouncer drops LISTEN state).
+        // NOTIFY/LISTEN may be unreliable through pgbouncer transaction pooling.
         this.pollTimer = setInterval(() => {
             if (this.activeJobs < this.maxConcurrent) {
                 this.tryPickup().catch((err) => {

--- a/packages/ghosthands/src/workflows/mastra/applyWorkflow.ts
+++ b/packages/ghosthands/src/workflows/mastra/applyWorkflow.ts
@@ -1,14 +1,19 @@
 /**
  * Apply Workflow — Assembles the gh_apply Mastra workflow.
  *
- * Flow:
- *   checkBlockers -> executeHandler
+ * Two workflow variants:
+ *   1. buildApplyWorkflow()          — checkBlockers -> executeHandler (existing, SmartApplyHandler)
+ *   2. buildDecisionApplyWorkflow()  — checkBlockers -> pageDecisionLoop (new, decision engine)
+ *
+ * Both share the same check_blockers_checkpoint step. The second step differs:
+ * - execute_handler delegates to SmartApplyHandler.execute()
+ * - page_decision_loop runs the internal observe-decide-act loop with tiered execution
  */
 
 import { createWorkflow } from '@mastra/core/workflows';
 
 import { workflowState, type RuntimeContext } from './types.js';
-import { buildSteps } from './steps/factory.js';
+import { buildSteps, buildPageDecisionLoopStep } from './steps/factory.js';
 
 /**
  * Build the committed gh_apply workflow with RuntimeContext captured via closure.
@@ -26,6 +31,42 @@ export function buildApplyWorkflow(rt: RuntimeContext) {
   })
     .then(checkBlockers)
     .then(executeHandler)
+    .commit();
+
+  return workflow;
+}
+
+// ---------------------------------------------------------------------------
+// Decision Engine Workflow (additive — does NOT modify buildApplyWorkflow)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the decision engine variant of the gh_apply workflow.
+ *
+ * Flow: checkBlockers -> pageDecisionLoop
+ *
+ * Uses the same check_blockers_checkpoint step for initial blocker detection,
+ * then runs the decision engine loop instead of SmartApplyHandler.
+ *
+ * @param rt - RuntimeContext (closure-injected, never serialized)
+ * @param loopRunnerFactory - Factory to create DecisionLoopRunner instances.
+ *   This is injected by the caller (jobExecutor) so the step does not
+ *   directly depend on engine/decision module resolution at import time.
+ */
+export function buildDecisionApplyWorkflow(
+  rt: RuntimeContext,
+  loopRunnerFactory: Parameters<typeof buildPageDecisionLoopStep>[1],
+) {
+  const { checkBlockers } = buildSteps(rt);
+  const pageDecisionLoop = buildPageDecisionLoopStep(rt, loopRunnerFactory);
+
+  const workflow = createWorkflow({
+    id: 'gh_apply_decision',
+    inputSchema: workflowState,
+    outputSchema: workflowState,
+  })
+    .then(checkBlockers)
+    .then(pageDecisionLoop)
     .commit();
 
   return workflow;

--- a/packages/ghosthands/src/workflows/mastra/steps/factory.ts
+++ b/packages/ghosthands/src/workflows/mastra/steps/factory.ts
@@ -562,3 +562,9 @@ export function buildSteps(rt: RuntimeContext) {
 
   return { checkBlockers, executeHandler };
 }
+
+// ---------------------------------------------------------------------------
+// Decision Engine Step (additive — does NOT modify buildSteps above)
+// ---------------------------------------------------------------------------
+
+export { buildPageDecisionLoopStep } from './pageDecisionLoop.js';

--- a/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
+++ b/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
@@ -95,7 +95,7 @@ async function detectBlockerSafe(
 // ---------------------------------------------------------------------------
 
 interface DecisionLoopResult {
-  terminalState: 'confirmation' | 'review_page' | 'submitted' | 'stuck' | 'budget_exceeded' | 'error' | 'max_iterations';
+  terminalState: 'confirmation' | 'review_page' | 'submitted' | 'blocked' | 'stuck' | 'budget_exceeded' | 'error' | 'max_iterations';
   terminationReason: string;
   iteration: number;
   pagesProcessed: number;

--- a/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
+++ b/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
@@ -1,0 +1,444 @@
+/**
+ * Page Decision Loop Step — Mastra step wrapping the DecisionLoopRunner.
+ *
+ * This step replaces `execute_handler` in the decision engine workflow.
+ * It runs an internal observe-decide-act loop within a single Mastra step,
+ * using the three-tier execution cascade (DOM -> Stagehand -> Magnitude).
+ *
+ * The entire loop runs inside one step execution because:
+ * - Mastra step boundaries serialize to Postgres (~200ms per transition)
+ * - The Playwright Page (browser session) cannot survive step boundaries
+ * - Sub-second iteration is required for responsive form filling
+ *
+ * HITL suspend is supported within the loop for blocker detection,
+ * using the same suspend() mechanism as check_blockers_checkpoint.
+ *
+ * ADDITIVE ONLY: This does NOT modify the existing execute_handler step.
+ */
+
+import { createStep } from '@mastra/core/workflows';
+
+import { workflowState, blockerResumeSchema, type RuntimeContext, type WorkflowState } from '../types.js';
+import { getLogger } from '../../../monitoring/logger.js';
+import { callbackNotifier } from '../../../workers/callbackNotifier.js';
+
+// ---------------------------------------------------------------------------
+// Types for the decision engine classes (implemented in engine/decision/)
+// These are imported from the engine layer once it is built.
+// ---------------------------------------------------------------------------
+
+// Forward-declare the interfaces we expect from engine/decision.
+// The actual implementations will be created in a subsequent task.
+// For now, this step defines the contract it expects.
+
+interface DecisionLoopResult {
+  terminalState: 'confirmation' | 'review_page' | 'submitted' | 'stuck' | 'budget_exceeded' | 'error' | 'max_iterations';
+  terminationReason: string;
+  iteration: number;
+  pagesProcessed: number;
+  currentPageFingerprint: string | null;
+  previousPageFingerprint: string | null;
+  samePageCount: number;
+  actionHistory: Array<{
+    iteration: number;
+    action: string;
+    target: string;
+    result: 'success' | 'partial' | 'failed' | 'skipped';
+    layer: 'dom' | 'stagehand' | 'magnitude' | null;
+    costUsd: number;
+    durationMs: number;
+    fieldsAttempted?: number;
+    fieldsFilled?: number;
+    pageFingerprint: string;
+    timestamp: number;
+  }>;
+  loopCostUsd: number;
+  /** Set when the loop encountered a blocker and needs HITL */
+  blockerDetected?: {
+    type: string;
+    confidence: number;
+    pageUrl: string;
+  };
+}
+
+interface DecisionLoopRunnerInterface {
+  run(): Promise<DecisionLoopResult>;
+}
+
+interface DecisionLoopRunnerFactory {
+  create(options: {
+    page: import('playwright').Page;
+    adapter: import('../../../adapters/types.js').HitlCapableAdapter;
+    costTracker: import('../../../workers/costControl.js').CostTracker;
+    platform: string;
+    targetUrl: string;
+    budgetUsd: number;
+    qualityPreset: 'speed' | 'balanced' | 'quality';
+    dataPrompt: string;
+    credentials: Record<string, string> | null;
+    logEvent: (eventType: string, metadata: Record<string, unknown>) => Promise<void>;
+    /** Previous action history from a resumed workflow */
+    previousActionHistory?: DecisionLoopResult['actionHistory'];
+    previousIteration?: number;
+  }): DecisionLoopRunnerInterface;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum action history entries to persist in workflow state */
+const MAX_PERSISTED_ACTION_HISTORY = 50;
+
+const logger = getLogger({ service: 'page-decision-loop' });
+
+// ---------------------------------------------------------------------------
+// Step Builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the page_decision_loop Mastra step with RuntimeContext captured via closure.
+ *
+ * This step:
+ * 1. Creates the DecisionLoopRunner with dependencies from RuntimeContext
+ * 2. Runs the observe-decide-act loop
+ * 3. Maps the result to WorkflowState updates (decisionLoop, metrics, status)
+ * 4. Handles HITL suspend for blockers detected during the loop
+ *
+ * @param rt - RuntimeContext (closure-injected, never serialized)
+ * @param loopRunnerFactory - Factory to create DecisionLoopRunner instances
+ */
+export function buildPageDecisionLoopStep(
+  rt: RuntimeContext,
+  loopRunnerFactory: DecisionLoopRunnerFactory,
+) {
+  return createStep({
+    id: 'page_decision_loop',
+    inputSchema: workflowState,
+    outputSchema: workflowState,
+    resumeSchema: blockerResumeSchema,
+    execute: async ({ inputData, resumeData, suspend }) => {
+      const state: WorkflowState = { ...inputData };
+
+      // Initialize decisionLoop state if not present (first run)
+      if (!state.decisionLoop) {
+        state.decisionLoop = {
+          iteration: 0,
+          pagesProcessed: 0,
+          currentPageFingerprint: null,
+          previousPageFingerprint: null,
+          samePageCount: 0,
+          actionHistory: [],
+          loopCostUsd: 0,
+          terminalState: 'running',
+          terminationReason: null,
+        };
+      }
+
+      // ── Handle HITL resume ──
+      if (resumeData) {
+        logger.info('Decision loop resuming from HITL suspension', {
+          jobId: state.jobId,
+          resolutionType: resumeData.resolutionType,
+          iteration: state.decisionLoop.iteration,
+        });
+
+        // Inject resolution into adapter (same pattern as check_blockers_checkpoint)
+        await rt.adapter.resume?.({ resolutionType: resumeData.resolutionType });
+
+        // Allow page to settle after human resolution
+        await new Promise((r) => setTimeout(r, 2000));
+
+        // Resume job status in DB
+        await rt.supabase
+          .from('gh_automation_jobs')
+          .update({ status: 'running', updated_at: new Date().toISOString() })
+          .eq('id', state.jobId);
+
+        // Notify VALET that the job has resumed
+        if (rt.job.callback_url) {
+          callbackNotifier.notifyResumed(
+            state.jobId,
+            rt.job.callback_url,
+            rt.job.valet_task_id,
+            rt.workerId,
+          ).catch((err) => {
+            logger.warn('Resume callback failed', {
+              jobId: state.jobId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }
+
+        state.hitl = {
+          blocked: false,
+          blockerType: null,
+          resumeNonce: null,
+          checkpoint: null,
+          attemptsByType: state.hitl.attemptsByType,
+          lastDecision: 'NO_ACTION',
+        };
+        state.status = 'running';
+      }
+
+      // ── Run the decision loop ──
+      logger.info('Starting decision loop', {
+        jobId: state.jobId,
+        platform: state.platform,
+        budgetUsd: state.budgetUsd,
+        qualityPreset: state.qualityPreset,
+        resuming: !!resumeData,
+        previousIteration: state.decisionLoop.iteration,
+      });
+
+      let result: DecisionLoopResult;
+
+      try {
+        const runner = loopRunnerFactory.create({
+          page: rt.adapter.page,
+          adapter: rt.adapter,
+          costTracker: rt.costTracker,
+          platform: state.platform,
+          targetUrl: state.targetUrl,
+          budgetUsd: state.budgetUsd,
+          qualityPreset: state.qualityPreset,
+          dataPrompt: rt.dataPrompt,
+          credentials: rt.credentials,
+          logEvent: rt.logEvent,
+          previousActionHistory: state.decisionLoop.actionHistory,
+          previousIteration: state.decisionLoop.iteration,
+        });
+
+        result = await runner.run();
+      } catch (runError) {
+        const msg = runError instanceof Error ? runError.message : String(runError);
+        logger.error('Decision loop threw an unhandled exception', {
+          jobId: state.jobId,
+          error: msg,
+        });
+
+        result = {
+          terminalState: 'error',
+          terminationReason: `Unhandled exception: ${msg}`,
+          iteration: state.decisionLoop.iteration,
+          pagesProcessed: state.decisionLoop.pagesProcessed,
+          currentPageFingerprint: state.decisionLoop.currentPageFingerprint,
+          previousPageFingerprint: state.decisionLoop.previousPageFingerprint,
+          samePageCount: state.decisionLoop.samePageCount,
+          actionHistory: state.decisionLoop.actionHistory,
+          loopCostUsd: state.decisionLoop.loopCostUsd,
+        };
+      }
+
+      // ── Handle blocker-triggered HITL suspend ──
+      if (result.blockerDetected) {
+        const { type, confidence, pageUrl } = result.blockerDetected;
+
+        logger.warn('Decision loop detected blocker, suspending for HITL', {
+          jobId: state.jobId,
+          blockerType: type,
+          confidence,
+          pageUrl,
+          iteration: result.iteration,
+        });
+
+        // Update job status to paused
+        await rt.supabase
+          .from('gh_automation_jobs')
+          .update({ status: 'paused', updated_at: new Date().toISOString() })
+          .eq('id', state.jobId)
+          .neq('status', 'paused');
+
+        // Log blocker event
+        await rt.logEvent('blocker_detected', {
+          jobId: state.jobId,
+          blockerType: type,
+          confidence,
+          pageUrl,
+          source: 'decision_loop',
+        });
+
+        // Persist loop state before suspending
+        const resumeNonce = crypto.randomUUID();
+        state.decisionLoop = {
+          ...mapLoopResult(result),
+          terminalState: 'running', // Still running, just paused for HITL
+        };
+        state.hitl = {
+          blocked: true,
+          blockerType: type,
+          resumeNonce,
+          checkpoint: 'page_decision_loop',
+          attemptsByType: state.hitl.attemptsByType,
+          lastDecision: 'IMMEDIATE_HITL',
+        };
+        state.status = 'suspended';
+
+        // Update cost metrics
+        const costSnapshot = rt.costTracker.getSnapshot();
+        state.metrics = {
+          ...state.metrics,
+          costUsd: costSnapshot.totalCost,
+          pagesProcessed: result.pagesProcessed,
+        };
+
+        // Notify VALET via callback
+        if (rt.job.callback_url) {
+          await callbackNotifier.notifyHumanNeeded(
+            state.jobId,
+            rt.job.callback_url,
+            {
+              type,
+              page_url: pageUrl,
+              description: `Blocker detected during decision loop: ${type}`,
+              metadata: {
+                blocker_confidence: confidence,
+                detection_method: 'decision_loop_observation',
+              },
+            },
+            rt.job.valet_task_id,
+            process.env.GH_WORKER_ID,
+            {
+              total_cost_usd: costSnapshot.totalCost,
+              action_count: costSnapshot.actionCount,
+              total_tokens: costSnapshot.inputTokens + costSnapshot.outputTokens,
+            },
+          );
+        }
+
+        return await suspend({ blockerType: type, pageUrl });
+      }
+
+      // ── Map result to workflow state ──
+      state.decisionLoop = mapLoopResult(result);
+
+      // Update cost metrics
+      const costSnapshot = rt.costTracker.getSnapshot();
+      state.metrics = {
+        ...state.metrics,
+        costUsd: costSnapshot.totalCost,
+        pagesProcessed: result.pagesProcessed,
+      };
+
+      // Map terminal state to workflow status
+      switch (result.terminalState) {
+        case 'confirmation':
+        case 'submitted':
+          state.status = 'completed';
+          state.handler = {
+            attempted: true,
+            success: true,
+            taskResult: {
+              success: true,
+              data: {
+                decision_engine: true,
+                iterations: result.iteration,
+                pages_processed: result.pagesProcessed,
+                terminal_state: result.terminalState,
+              },
+            },
+          };
+          break;
+
+        case 'review_page':
+          state.status = 'awaiting_review';
+          state.handler = {
+            attempted: true,
+            success: true,
+            taskResult: {
+              success: true,
+              data: {
+                decision_engine: true,
+                iterations: result.iteration,
+                pages_processed: result.pagesProcessed,
+                terminal_state: result.terminalState,
+              },
+              awaitingUserReview: true,
+              keepBrowserOpen: true,
+            },
+          };
+          break;
+
+        case 'stuck':
+        case 'max_iterations':
+          state.status = 'awaiting_review';
+          state.handler = {
+            attempted: true,
+            success: false,
+            taskResult: {
+              success: false,
+              error: result.terminationReason,
+              data: {
+                decision_engine: true,
+                iterations: result.iteration,
+                pages_processed: result.pagesProcessed,
+                terminal_state: result.terminalState,
+              },
+              awaitingUserReview: true,
+              keepBrowserOpen: true,
+            },
+          };
+          break;
+
+        case 'budget_exceeded':
+        case 'error':
+          state.status = 'failed';
+          state.handler = {
+            attempted: true,
+            success: false,
+            taskResult: {
+              success: false,
+              error: result.terminationReason,
+              data: {
+                decision_engine: true,
+                iterations: result.iteration,
+                pages_processed: result.pagesProcessed,
+                terminal_state: result.terminalState,
+              },
+            },
+          };
+          break;
+      }
+
+      logger.info('Decision loop completed', {
+        jobId: state.jobId,
+        terminalState: result.terminalState,
+        terminationReason: result.terminationReason,
+        iterations: result.iteration,
+        pagesProcessed: result.pagesProcessed,
+        totalActions: result.actionHistory.length,
+        loopCostUsd: result.loopCostUsd,
+        status: state.status,
+      });
+
+      return state;
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a DecisionLoopResult to the decisionLoop field of WorkflowState,
+ * trimming action history to the max persisted length.
+ */
+function mapLoopResult(result: DecisionLoopResult): NonNullable<WorkflowState['decisionLoop']> {
+  // Trim action history to max persisted entries (keep most recent)
+  const trimmedHistory = result.actionHistory.length > MAX_PERSISTED_ACTION_HISTORY
+    ? result.actionHistory.slice(-MAX_PERSISTED_ACTION_HISTORY)
+    : result.actionHistory;
+
+  return {
+    iteration: result.iteration,
+    pagesProcessed: result.pagesProcessed,
+    currentPageFingerprint: result.currentPageFingerprint,
+    previousPageFingerprint: result.previousPageFingerprint,
+    samePageCount: result.samePageCount,
+    actionHistory: trimmedHistory,
+    loopCostUsd: result.loopCostUsd,
+    terminalState: result.terminalState,
+    terminationReason: result.terminationReason,
+  };
+}

--- a/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
+++ b/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
@@ -91,38 +91,20 @@ async function detectBlockerSafe(
 }
 
 // ---------------------------------------------------------------------------
-// Types for the decision engine classes (implemented in engine/decision/)
+// Types for the decision engine classes (imported from engine/decision/)
 // ---------------------------------------------------------------------------
 
-interface DecisionLoopResult {
-  terminalState: 'confirmation' | 'review_page' | 'submitted' | 'blocked' | 'stuck' | 'budget_exceeded' | 'error' | 'max_iterations';
-  terminationReason: string;
-  iteration: number;
-  pagesProcessed: number;
-  currentPageFingerprint: string | null;
-  previousPageFingerprint: string | null;
-  samePageCount: number;
-  actionHistory: Array<{
-    iteration: number;
-    action: string;
-    target: string;
-    result: 'success' | 'partial' | 'failed' | 'skipped';
-    layer: 'dom' | 'stagehand' | 'magnitude' | null;
-    costUsd: number;
-    durationMs: number;
-    fieldsAttempted?: number;
-    fieldsFilled?: number;
-    pageFingerprint: string;
-    timestamp: number;
-  }>;
-  loopCostUsd: number;
-  /** Set when the loop encountered a blocker and needs HITL */
+import type { DecisionLoopState, ActionHistoryEntry } from '../../../engine/decision/types.js';
+import type { CostTracker } from '../../../workers/costControl.js';
+
+/** Result returned by DecisionLoopRunner.run() */
+type DecisionLoopResult = DecisionLoopState & {
   blockerDetected?: {
     type: string;
     confidence: number;
     pageUrl: string;
   };
-}
+};
 
 interface DecisionLoopRunnerInterface {
   run(): Promise<DecisionLoopResult>;
@@ -132,16 +114,11 @@ interface DecisionLoopRunnerFactory {
   create(options: {
     page: import('playwright').Page;
     adapter: import('../../../adapters/types.js').HitlCapableAdapter;
-    costTracker: import('../../../workers/costControl.js').CostTracker;
+    costTracker: CostTracker;
     platform: string;
-    targetUrl: string;
     budgetUsd: number;
-    qualityPreset: 'speed' | 'balanced' | 'quality';
-    dataPrompt: string;
-    credentials: Record<string, string> | null;
     logEvent: (eventType: string, metadata: Record<string, unknown>) => Promise<void>;
-    /** Previous action history from a resumed workflow */
-    previousActionHistory?: DecisionLoopResult['actionHistory'];
+    previousActionHistory?: ActionHistoryEntry[];
     previousIteration?: number;
   }): DecisionLoopRunnerInterface;
 }
@@ -292,11 +269,7 @@ export function buildPageDecisionLoopStep(
           adapter: rt.adapter,
           costTracker: rt.costTracker,
           platform: state.platform,
-          targetUrl: state.targetUrl,
           budgetUsd: state.budgetUsd,
-          qualityPreset: state.qualityPreset,
-          dataPrompt: rt.dataPrompt,
-          credentials: rt.credentials,
           logEvent: rt.logEvent,
           previousActionHistory: state.decisionLoop.actionHistory,
           previousIteration: state.decisionLoop.iteration,
@@ -460,7 +433,7 @@ export function buildPageDecisionLoopStep(
             success: false,
             taskResult: {
               success: false,
-              error: result.terminationReason,
+              error: result.terminationReason ?? undefined,
               data: {
                 decision_engine: true,
                 iterations: result.iteration,
@@ -481,7 +454,7 @@ export function buildPageDecisionLoopStep(
             success: false,
             taskResult: {
               success: false,
-              error: result.terminationReason,
+              error: result.terminationReason ?? undefined,
               data: {
                 decision_engine: true,
                 iterations: result.iteration,

--- a/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
+++ b/packages/ghosthands/src/workflows/mastra/steps/pageDecisionLoop.ts
@@ -21,15 +21,78 @@ import { createStep } from '@mastra/core/workflows';
 import { workflowState, blockerResumeSchema, type RuntimeContext, type WorkflowState } from '../types.js';
 import { getLogger } from '../../../monitoring/logger.js';
 import { callbackNotifier } from '../../../workers/callbackNotifier.js';
+import { BlockerDetector } from '../../../detection/BlockerDetector.js';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// ---------------------------------------------------------------------------
+// HITL resume helpers (ported from factory.ts check_blockers_checkpoint)
+// ---------------------------------------------------------------------------
+
+const blockerDetector = new BlockerDetector();
+
+async function readAndClearResolutionData(
+  supabase: SupabaseClient,
+  jobId: string,
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await supabase
+    .from('gh_automation_jobs')
+    .select('interaction_data')
+    .eq('id', jobId)
+    .single();
+
+  if (error || !data?.interaction_data) return null;
+
+  const interactionData = data.interaction_data as Record<string, unknown>;
+  const resolutionData = (interactionData.resolution_data as Record<string, unknown>) ?? null;
+
+  const stripped = { ...interactionData };
+  delete stripped.resolution_data;
+  delete stripped.resolution_type;
+  delete stripped.resolved_by;
+  delete stripped.resolved_at;
+  delete stripped.otp;
+  delete stripped.credentials;
+
+  await supabase
+    .from('gh_automation_jobs')
+    .update({ interaction_data: stripped })
+    .eq('id', jobId);
+
+  return resolutionData;
+}
+
+async function injectResolution(
+  adapter: { act: (instruction: string, opts?: { data?: Record<string, unknown> }) => Promise<any> },
+  resolution: Record<string, unknown>,
+): Promise<void> {
+  const resolutionType = resolution.type as string | undefined;
+  if (resolutionType === 'code_entry' && resolution.code) {
+    await adapter.act(`Type "${resolution.code}" into the verification code input field`);
+  } else if (resolutionType === 'credentials' && resolution.username) {
+    if (resolution.username) {
+      await adapter.act(`Type "${resolution.username}" into the username or email field`);
+    }
+    if (resolution.password) {
+      await adapter.act(`Type the password into the password field`, {
+        data: { password: resolution.password as string },
+      });
+    }
+  }
+}
+
+async function detectBlockerSafe(
+  adapter: import('../../../adapters/types.js').HitlCapableAdapter,
+): Promise<{ type: string; confidence: number } | null> {
+  try {
+    return await blockerDetector.detectWithAdapter(adapter);
+  } catch {
+    return null;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Types for the decision engine classes (implemented in engine/decision/)
-// These are imported from the engine layer once it is built.
 // ---------------------------------------------------------------------------
-
-// Forward-declare the interfaces we expect from engine/decision.
-// The actual implementations will be created in a subsequent task.
-// For now, this step defines the contract it expects.
 
 interface DecisionLoopResult {
   terminalState: 'confirmation' | 'review_page' | 'submitted' | 'stuck' | 'budget_exceeded' | 'error' | 'max_iterations';
@@ -143,11 +206,41 @@ export function buildPageDecisionLoopStep(
           iteration: state.decisionLoop.iteration,
         });
 
-        // Inject resolution into adapter (same pattern as check_blockers_checkpoint)
+        // Read sensitive resolution data from DB (OTP codes, credentials, etc.)
+        const resolutionData = await readAndClearResolutionData(rt.supabase, state.jobId);
+
+        // Inject resolution data (2FA code, login credentials) into adapter
+        if (resolutionData && (resolutionData.code || resolutionData.username)) {
+          await injectResolution(rt.adapter, {
+            ...resolutionData,
+            type: resumeData.resolutionType,
+          });
+        }
+
+        // Resume the adapter
         await rt.adapter.resume?.({ resolutionType: resumeData.resolutionType });
 
-        // Allow page to settle after human resolution
-        await new Promise((r) => setTimeout(r, 2000));
+        // Verify blocker is actually cleared (up to 3 attempts, 2s apart)
+        let stillBlocked = false;
+        for (let attempt = 0; attempt < 3; attempt++) {
+          await new Promise((r) => setTimeout(r, 2000));
+          const blockerCheck = await detectBlockerSafe(rt.adapter);
+          if (!blockerCheck) {
+            stillBlocked = false;
+            break;
+          }
+          stillBlocked = true;
+        }
+
+        if (stillBlocked) {
+          // Blocker persists after human resolution — re-suspend
+          logger.warn('Blocker persists after HITL resolution', {
+            jobId: state.jobId,
+            resolutionType: resumeData.resolutionType,
+          });
+          const currentUrl = await rt.adapter.getCurrentUrl?.().catch(() => state.targetUrl) ?? state.targetUrl;
+          return await suspend({ blockerType: 'context_lost', pageUrl: currentUrl });
+        }
 
         // Resume job status in DB
         await rt.supabase

--- a/packages/ghosthands/src/workflows/mastra/types.ts
+++ b/packages/ghosthands/src/workflows/mastra/types.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { BrowserAutomationAdapter, HitlCapableAdapter } from '../../adapters/types.js';
 import type { PageContextService } from '../../context/PageContextService.js';
+import { DecisionLoopStateSchema } from '../../engine/decision/types.js';
 import type { CostTracker } from '../../workers/costControl.js';
 import type { ProgressTracker } from '../../workers/progressTracker.js';
 import type { EmailVerificationService } from '../../workers/emailVerification/types.js';
@@ -59,33 +60,9 @@ export const workflowState = z.object({
     'failed',
   ]).default('running'),
 
-  // Decision loop state (only present when using page_decision_loop step)
-  decisionLoop: z.object({
-    iteration: z.number().int().nonnegative().default(0),
-    pagesProcessed: z.number().int().nonnegative().default(0),
-    currentPageFingerprint: z.string().nullable().default(null),
-    previousPageFingerprint: z.string().nullable().default(null),
-    samePageCount: z.number().int().nonnegative().default(0),
-    actionHistory: z.array(z.object({
-      iteration: z.number(),
-      action: z.string(),
-      target: z.string(),
-      result: z.enum(['success', 'partial', 'failed', 'skipped']),
-      layer: z.enum(['dom', 'stagehand', 'magnitude']).nullable(),
-      costUsd: z.number(),
-      durationMs: z.number(),
-      fieldsAttempted: z.number().optional(),
-      fieldsFilled: z.number().optional(),
-      pageFingerprint: z.string(),
-      timestamp: z.number(),
-    })).default([]),
-    loopCostUsd: z.number().default(0),
-    terminalState: z.enum([
-      'running', 'confirmation', 'review_page', 'submitted',
-      'blocked', 'stuck', 'budget_exceeded', 'error', 'max_iterations',
-    ]).default('running'),
-    terminationReason: z.string().nullable().default(null),
-  }).optional(),
+  // Decision loop state (only present when using page_decision_loop step).
+  // Schema imported from the canonical source in engine/decision/types.
+  decisionLoop: DecisionLoopStateSchema.optional(),
 });
 
 export type WorkflowState = z.infer<typeof workflowState>;

--- a/packages/ghosthands/src/workflows/mastra/types.ts
+++ b/packages/ghosthands/src/workflows/mastra/types.ts
@@ -5,7 +5,7 @@ import type { PageContextService } from '../../context/PageContextService.js';
 import type { CostTracker } from '../../workers/costControl.js';
 import type { ProgressTracker } from '../../workers/progressTracker.js';
 import type { EmailVerificationService } from '../../workers/emailVerification/types.js';
-import type { TaskHandler, AutomationJob } from '../../workers/taskHandlers/types.js';
+import type { TaskHandler, AutomationJob, AnthropicClientConfig } from '../../workers/taskHandlers/types.js';
 
 // ---------------------------------------------------------------------------
 // Serializable Workflow State (persisted by Mastra in PostgresStore)
@@ -109,6 +109,10 @@ export interface RuntimeContext {
   logEvent: (eventType: string, metadata: Record<string, unknown>) => Promise<void>;
   workerId: string;
   uploadScreenshot?: (jobId: string, name: string, buffer: Buffer) => Promise<string>;
+  /** LLM client config for the decision engine (VALET proxy baseURL + managed grant). */
+  llmClientConfig?: {
+    anthropic?: AnthropicClientConfig;
+  };
   /** Block handler execution until human completes a manual action (email verification, etc.) */
   waitForManualAction?: (options: {
     type: string;

--- a/packages/ghosthands/src/workflows/mastra/types.ts
+++ b/packages/ghosthands/src/workflows/mastra/types.ts
@@ -82,7 +82,7 @@ export const workflowState = z.object({
     loopCostUsd: z.number().default(0),
     terminalState: z.enum([
       'running', 'confirmation', 'review_page', 'submitted',
-      'stuck', 'budget_exceeded', 'error', 'max_iterations',
+      'blocked', 'stuck', 'budget_exceeded', 'error', 'max_iterations',
     ]).default('running'),
     terminationReason: z.string().nullable().default(null),
   }).optional(),

--- a/packages/ghosthands/src/workflows/mastra/types.ts
+++ b/packages/ghosthands/src/workflows/mastra/types.ts
@@ -58,6 +58,34 @@ export const workflowState = z.object({
     'completed',
     'failed',
   ]).default('running'),
+
+  // Decision loop state (only present when using page_decision_loop step)
+  decisionLoop: z.object({
+    iteration: z.number().int().nonnegative().default(0),
+    pagesProcessed: z.number().int().nonnegative().default(0),
+    currentPageFingerprint: z.string().nullable().default(null),
+    previousPageFingerprint: z.string().nullable().default(null),
+    samePageCount: z.number().int().nonnegative().default(0),
+    actionHistory: z.array(z.object({
+      iteration: z.number(),
+      action: z.string(),
+      target: z.string(),
+      result: z.enum(['success', 'partial', 'failed', 'skipped']),
+      layer: z.enum(['dom', 'stagehand', 'magnitude']).nullable(),
+      costUsd: z.number(),
+      durationMs: z.number(),
+      fieldsAttempted: z.number().optional(),
+      fieldsFilled: z.number().optional(),
+      pageFingerprint: z.string(),
+      timestamp: z.number(),
+    })).default([]),
+    loopCostUsd: z.number().default(0),
+    terminalState: z.enum([
+      'running', 'confirmation', 'review_page', 'submitted',
+      'stuck', 'budget_exceeded', 'error', 'max_iterations',
+    ]).default('running'),
+    terminationReason: z.string().nullable().default(null),
+  }).optional(),
 });
 
 export type WorkflowState = z.infer<typeof workflowState>;


### PR DESCRIPTION
## Summary

- **Post-auth observation gap**: When the page scanner returns `fields=0 buttons=0` (common during page transitions after auth submit), the decision loop now waits 2s and re-scans before counting it as a same-page iteration. This prevents the 6-iteration stuck termination on transitional pages.
- **networkidle wait**: After successful actions or page navigation, waits for `networkidle` (5s timeout) for better page stability before the next observation cycle.
- **BlockerDetector race elimination**: Skips the background `blockerCheckInterval` for `mastra_decision` execution mode since the decision loop has its own built-in blocker detection. Prevents concurrent `page.evaluate()` race conditions.
- **Stale LISTEN/NOTIFY comment**: Fixed incorrect TODO in JobPoller claiming `pg_notify('gh_job_created', ...)` is never called — it IS fired by the VALET API route (`valet.ts:280`).

## Files Changed

| File | Change |
|------|--------|
| `DecisionLoopRunner.ts` | Empty-page re-observation + networkidle post-action wait |
| `JobExecutor.ts` | Skip background blocker checks for mastra_decision |
| `JobPoller.ts` | Fix stale LISTEN/NOTIFY comment |

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally, 0 errors)
- [ ] Workday create-account flow no longer gets stuck with fields=0 buttons=0
- [ ] SmartRecruiters auth transitions observed correctly after re-scan
- [ ] mastra_decision jobs have no concurrent page access from BlockerDetector

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wekruit/ghost-hands/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
